### PR TITLE
Remove unused key and RFC 4627 formatting

### DIFF
--- a/pokedex.json
+++ b/pokedex.json
@@ -7448,6 +7448,16 @@
             "types": [
                 "Water",
                 "Dragon"
+            ],
+            "raid_level":5,
+            "availability_rules":[
+                [
+                    {
+                        "type":"time",
+                        "start":"2019-01-29T21:00:00Z",
+                        "end":"2019-02-28T21:00:00Z"
+                    }
+                ]
             ]
         }
     },

--- a/pokedex.json
+++ b/pokedex.json
@@ -1,7606 +1,7236 @@
 [
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Bulbasaur",
-            "id": "001",
-            "shiny": true,
-            "raid_level": 1,
-            "perfect_cp": 637,
-            "perfect_cp_boosted": 796,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Grass",
-                "Poison"
-            ],
-            "perfect_boosted": 796
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Ivysaur",
-            "id": "002",
-            "types": [
-                "Grass",
-                "Poison"
-            ],
-            "perfect_cp": 970,
-            "perfect_boosted": 1213,
-            "perfect_cp_boosted": 1213
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Venusaur",
-            "id": "003",
-            "types": [
-                "Grass",
-                "Poison"
-            ],
-            "perfect_cp": 1554,
-            "perfect_boosted": 1943,
-            "perfect_cp_boosted": 1943
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Charmander",
-            "id": "004",
-            "shiny": true,
-            "raid_level": 1,
-            "perfect_cp": 560,
-            "perfect_cp_boosted": 700,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Fire"
-            ],
-            "perfect_boosted": 700
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Charmeleon",
-            "id": "005",
-            "types": [
-                "Fire"
-            ],
-            "perfect_cp": 944,
-            "perfect_boosted": 1180,
-            "perfect_cp_boosted": 1180
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Charizard",
-            "id": "006",
-            "types": [
-                "Fire",
-                "Flying"
-            ],
-            "perfect_cp": 1651,
-            "perfect_boosted": 2064,
-            "perfect_cp_boosted": 2064
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Squirtle",
-            "id": "007",
-            "shiny": true,
-            "raid_level": 1,
-            "perfect_cp": 540,
-            "perfect_cp_boosted": 675,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Water"
-            ],
-            "perfect_boosted": 675
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Wartortle",
-            "id": "008",
-            "types": [
-                "Water"
-            ],
-            "perfect_cp": 850,
-            "perfect_boosted": 1063,
-            "perfect_cp_boosted": 1063
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Blastoise",
-            "id": "009",
-            "types": [
-                "Water"
-            ],
-            "perfect_cp": 1409,
-            "perfect_boosted": 1761,
-            "perfect_cp_boosted": 1761
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Caterpie",
-            "id": "010",
-            "types": [
-                "Bug"
-            ],
-            "perfect_cp": 249,
-            "perfect_boosted": 312,
-            "perfect_cp_boosted": 312
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Metapod",
-            "id": "011",
-            "types": [
-                "Bug"
-            ],
-            "perfect_cp": 257,
-            "perfect_boosted": 321,
-            "perfect_cp_boosted": 321
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Butterfree",
-            "id": "012",
-            "types": [
-                "Bug",
-                "Flying"
-            ],
-            "perfect_cp": 1044,
-            "perfect_boosted": 1305,
-            "perfect_cp_boosted": 1305
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Weedle",
-            "id": "013",
-            "types": [
-                "Bug",
-                "Poison"
-            ],
-            "perfect_cp": 260,
-            "perfect_boosted": 325,
-            "perfect_cp_boosted": 325
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Kakuna",
-            "id": "014",
-            "types": [
-                "Bug",
-                "Poison"
-            ],
-            "perfect_cp": 246,
-            "perfect_boosted": 308,
-            "perfect_cp_boosted": 308
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Beedrill",
-            "id": "015",
-            "types": [
-                "Bug",
-                "Poison"
-            ],
-            "perfect_cp": 1054,
-            "perfect_boosted": 1318,
-            "perfect_cp_boosted": 1318
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Pidgey",
-            "id": "016",
-            "types": [
-                "Normal",
-                "Flying"
-            ],
-            "perfect_cp": 388,
-            "perfect_boosted": 486,
-            "perfect_cp_boosted": 486
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Pidgeotto",
-            "id": "017",
-            "types": [
-                "Normal",
-                "Flying"
-            ],
-            "perfect_cp": 682,
-            "perfect_boosted": 853,
-            "perfect_cp_boosted": 853
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Pidgeot",
-            "id": "018",
-            "types": [
-                "Normal",
-                "Flying"
-            ],
-            "perfect_cp": 1216,
-            "perfect_boosted": 1521,
-            "perfect_cp_boosted": 1521
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Rattata",
-            "id": "019",
-            "types": [
-                "Dark",
-                "Normal"
-            ],
-            "perfect_cp": 419,
-            "perfect_boosted": 524,
-            "perfect_cp_boosted": 524
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Raticate",
-            "id": "020",
-            "types": [
-                "Dark",
-                "Normal"
-            ],
-            "perfect_cp": 974,
-            "perfect_boosted": 1217,
-            "perfect_cp_boosted": 1217
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Spearow",
-            "id": "021",
-            "types": [
-                "Normal",
-                "Flying"
-            ],
-            "perfect_cp": 456,
-            "perfect_boosted": 570,
-            "perfect_cp_boosted": 570
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Fearow",
-            "id": "022",
-            "types": [
-                "Normal",
-                "Flying"
-            ],
-            "perfect_cp": 1141,
-            "perfect_boosted": 1426,
-            "perfect_cp_boosted": 1426
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Ekans",
-            "id": "023",
-            "types": [
-                "Poison"
-            ],
-            "perfect_cp": 529,
-            "perfect_boosted": 662,
-            "perfect_cp_boosted": 662
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Arbok",
-            "id": "024",
-            "types": [
-                "Poison"
-            ],
-            "perfect_cp": 1097,
-            "perfect_boosted": 1372,
-            "perfect_cp_boosted": 1372
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Pikachu",
-            "id": "025",
-            "types": [
-                "Electric"
-            ],
-            "perfect_cp": 536,
-            "perfect_boosted": 670,
-            "perfect_cp_boosted": 670
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Raichu",
-            "id": "026",
-            "raid_level": 3,
-            "types": [
-                "Electric",
-                "Psychic"
-            ],
-            "perfect_cp": 1306,
-            "perfect_boosted": 1633,
-            "perfect_cp_boosted": 1633,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Sandshrew",
-            "id": "027",
-            "types": [
-                "Ice",
-                "Steel"
-            ],
-            "perfect_cp": 739,
-            "perfect_boosted": 924,
-            "perfect_cp_boosted": 924
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Sandslash",
-            "id": "028",
-            "types": [
-                "Ice",
-                "Steel"
-            ],
-            "perfect_cp": 1390,
-            "perfect_boosted": 1737,
-            "perfect_cp_boosted": 1737,
-            "raid_level": 2,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Nidoran Female",
-            "id": "029",
-            "types": [
-                "Poison"
-            ],
-            "perfect_cp": 466,
-            "perfect_boosted": 583,
-            "perfect_cp_boosted": 583
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Nidorina",
-            "id": "030",
-            "types": [
-                "Poison"
-            ],
-            "perfect_cp": 748,
-            "perfect_boosted": 935,
-            "perfect_cp_boosted": 935
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Nidoqueen",
-            "id": "031",
-            "types": [
-                "Poison",
-                "Ground"
-            ],
-            "perfect_cp": 1421,
-            "perfect_boosted": 1777,
-            "perfect_cp_boosted": 1777
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Nidoran Male",
-            "id": "032",
-            "types": [
-                "Poison"
-            ],
-            "perfect_cp": 491,
-            "perfect_boosted": 614,
-            "perfect_cp_boosted": 614
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Nidorino",
-            "id": "033",
-            "types": [
-                "Poison"
-            ],
-            "perfect_cp": 796,
-            "perfect_boosted": 995,
-            "perfect_cp_boosted": 995
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Nidoking",
-            "id": "034",
-            "types": [
-                "Poison",
-                "Ground"
-            ],
-            "perfect_cp": 1466,
-            "perfect_boosted": 1833,
-            "perfect_cp_boosted": 1833
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Clefairy",
-            "id": "035",
-            "types": [
-                "Fairy"
-            ],
-            "perfect_cp": 660,
-            "perfect_boosted": 825,
-            "perfect_cp_boosted": 825
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Clefable",
-            "id": "036",
-            "types": [
-                "Fairy"
-            ],
-            "perfect_cp": 1392,
-            "perfect_boosted": 1741,
-            "perfect_cp_boosted": 1741
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Vulpix",
-            "id": "037",
-            "types": [
-                "Ice"
-            ],
-            "perfect_cp": 504,
-            "perfect_boosted": 631,
-            "perfect_cp_boosted": 631
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Ninetales",
-            "id": "038",
-            "types": [
-                "Ice",
-                "Fairy"
-            ],
-            "perfect_cp": 1319,
-            "perfect_boosted": 1649,
-            "perfect_cp_boosted": 1649
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Jigglypuff",
-            "id": "039",
-            "types": [
-                "Normal",
-                "Fairy"
-            ],
-            "perfect_cp": 413,
-            "perfect_boosted": 517,
-            "perfect_cp_boosted": 517
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Wigglytuff",
-            "id": "040",
-            "types": [
-                "Normal",
-                "Fairy"
-            ],
-            "perfect_cp": 1101,
-            "perfect_boosted": 1376,
-            "perfect_cp_boosted": 1376
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Zubat",
-            "id": "041",
-            "types": [
-                "Poison",
-                "Flying"
-            ],
-            "perfect_cp": 381,
-            "perfect_boosted": 476,
-            "perfect_cp_boosted": 476
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Golbat",
-            "id": "042",
-            "types": [
-                "Poison",
-                "Flying"
-            ],
-            "perfect_cp": 1129,
-            "perfect_boosted": 1412,
-            "perfect_cp_boosted": 1412
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Oddish",
-            "id": "043",
-            "types": [
-                "Grass",
-                "Poison"
-            ],
-            "perfect_cp": 702,
-            "perfect_boosted": 877,
-            "perfect_cp_boosted": 877
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Gloom",
-            "id": "044",
-            "types": [
-                "Grass",
-                "Poison"
-            ],
-            "perfect_cp": 960,
-            "perfect_boosted": 1200,
-            "perfect_cp_boosted": 1200
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Vileplume",
-            "id": "045",
-            "types": [
-                "Grass",
-                "Poison"
-            ],
-            "perfect_cp": 1462,
-            "perfect_boosted": 1828,
-            "perfect_cp_boosted": 1828
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Paras",
-            "id": "046",
-            "types": [
-                "Bug",
-                "Grass"
-            ],
-            "perfect_cp": 581,
-            "perfect_boosted": 727,
-            "perfect_cp_boosted": 727
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Parasect",
-            "id": "047",
-            "types": [
-                "Bug",
-                "Grass"
-            ],
-            "perfect_cp": 1062,
-            "perfect_boosted": 1328,
-            "perfect_cp_boosted": 1328
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Venonat",
-            "id": "048",
-            "types": [
-                "Bug",
-                "Poison"
-            ],
-            "perfect_cp": 573,
-            "perfect_boosted": 717,
-            "perfect_cp_boosted": 717
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Venomoth",
-            "id": "049",
-            "raid_level": 2,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Bug",
-                "Poison"
-            ],
-            "perfect_cp": 1190,
-            "perfect_boosted": 1487,
-            "perfect_cp_boosted": 1487
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Diglett",
-            "id": "050",
-            "types": [
-                "Ground",
-                "Steel"
-            ],
-            "perfect_cp": 394,
-            "perfect_boosted": 493,
-            "perfect_cp_boosted": 493
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Dugtrio",
-            "id": "051",
-            "types": [
-                "Ground",
-                "Steel"
-            ],
-            "perfect_cp": 1094,
-            "perfect_boosted": 1368,
-            "perfect_cp_boosted": 1368
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Meowth",
-            "id": "052",
-            "types": [
-                "Dark"
-            ],
-            "perfect_cp": 455,
-            "perfect_boosted": 569,
-            "perfect_cp_boosted": 569
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Persian",
-            "id": "053",
-            "types": [
-                "Dark"
-            ],
-            "perfect_cp": 1012,
-            "perfect_boosted": 1265,
-            "perfect_cp_boosted": 1265
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Psyduck",
-            "id": "054",
-            "types": [
-                "Water"
-            ],
-            "perfect_cp": 632,
-            "perfect_boosted": 790,
-            "perfect_cp_boosted": 790
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Golduck",
-            "id": "055",
-            "types": [
-                "Water"
-            ],
-            "perfect_cp": 1400,
-            "perfect_boosted": 1750,
-            "perfect_cp_boosted": 1750
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Mankey",
-            "id": "056",
-            "types": [
-                "Fighting"
-            ],
-            "perfect_cp": 665,
-            "perfect_boosted": 832,
-            "perfect_cp_boosted": 832
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Primeape",
-            "id": "057",
-            "raid_level": 2,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Fighting"
-            ],
-            "perfect_cp": 1307,
-            "perfect_boosted": 1634,
-            "perfect_cp_boosted": 1634
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Growlithe",
-            "id": "058",
-            "types": [
-                "Fire"
-            ],
-            "perfect_cp": 710,
-            "perfect_boosted": 888,
-            "perfect_cp_boosted": 888
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Arcanine",
-            "id": "059",
-            "types": [
-                "Fire"
-            ],
-            "perfect_cp": 1731,
-            "perfect_boosted": 2164,
-            "perfect_cp_boosted": 2164
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Poliwag",
-            "id": "060",
-            "types": [
-                "Water"
-            ],
-            "perfect_cp": 473,
-            "perfect_boosted": 592,
-            "perfect_cp_boosted": 592
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Poliwhirl",
-            "id": "061",
-            "types": [
-                "Water"
-            ],
-            "perfect_cp": 811,
-            "perfect_boosted": 1013,
-            "perfect_cp_boosted": 1013
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Poliwrath",
-            "id": "062",
-            "raid_level": 4,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Water",
-                "Fighting"
-            ],
-            "perfect_cp": 1477,
-            "perfect_boosted": 1847,
-            "perfect_cp_boosted": 1847
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Abra",
-            "id": "063",
-            "types": [
-                "Psychic"
-            ],
-            "perfect_cp": 767,
-            "perfect_boosted": 958,
-            "perfect_cp_boosted": 958
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Kadabra",
-            "id": "064",
-            "types": [
-                "Psychic"
-            ],
-            "perfect_cp": 1176,
-            "perfect_boosted": 1471,
-            "perfect_cp_boosted": 1471
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Alakazam",
-            "id": "065",
-            "raid_level": 3,
-            "types": [
-                "Psychic"
-            ],
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "perfect_cp": 1747,
-            "perfect_boosted": 2184,
-            "perfect_cp_boosted": 2184
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Machop",
-            "id": "066",
-            "types": [
-                "Fighting"
-            ],
-            "perfect_cp": 730,
-            "perfect_boosted": 913,
-            "perfect_cp_boosted": 913
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Machoke",
-            "id": "067",
-            "types": [
-                "Fighting"
-            ],
-            "perfect_cp": 1160,
-            "perfect_boosted": 1451,
-            "perfect_cp_boosted": 1451
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Machamp",
-            "id": "068",
-            "raid_level": 3,
-            "perfect_cp": 1746,
-            "perfect_cp_boosted": 2183,
-            "types": [
-                "Fighting"
-            ],
-            "perfect_boosted": 2183,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Bellsprout",
-            "id": "069",
-            "types": [
-                "Grass",
-                "Poison"
-            ],
-            "perfect_cp": 590,
-            "perfect_boosted": 738,
-            "perfect_cp_boosted": 738
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Weepinbell",
-            "id": "070",
-            "types": [
-                "Grass",
-                "Poison"
-            ],
-            "perfect_cp": 921,
-            "perfect_boosted": 1151,
-            "perfect_cp_boosted": 1151
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Victreebel",
-            "id": "071",
-            "types": [
-                "Grass",
-                "Poison"
-            ],
-            "perfect_cp": 1389,
-            "perfect_boosted": 1736,
-            "perfect_cp_boosted": 1736
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Tentacool",
-            "id": "072",
-            "types": [
-                "Water",
-                "Poison"
-            ],
-            "perfect_cp": 594,
-            "perfect_boosted": 743,
-            "perfect_cp_boosted": 743
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Tentacruel",
-            "id": "073",
-            "raid_level": 2,
-            "perfect_cp": 1384,
-            "perfect_cp_boosted": 1730,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Water",
-                "Poison"
-            ],
-            "perfect_boosted": 1730
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Geodude",
-            "id": "074",
-            "types": [
-                "Rock",
-                "Electric"
-            ],
-            "perfect_cp": 739,
-            "perfect_boosted": 923,
-            "perfect_cp_boosted": 923
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Graveler",
-            "id": "075",
-            "types": [
-                "Rock",
-                "Electric"
-            ],
-            "perfect_cp": 1084,
-            "perfect_boosted": 1355,
-            "perfect_cp_boosted": 1355
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Golem",
-            "id": "076",
-            "raid_level": 4,
-            "types": [
-                "Rock",
-                "Electric"
-            ],
-            "perfect_cp": 1685,
-            "perfect_boosted": 2106,
-            "perfect_cp_boosted": 2106,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Ponyta",
-            "id": "077",
-            "types": [
-                "Fire"
-            ],
-            "perfect_cp": 969,
-            "perfect_boosted": 1212,
-            "perfect_cp_boosted": 1212
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Rapidash",
-            "id": "078",
-            "types": [
-                "Fire"
-            ],
-            "perfect_cp": 1406,
-            "perfect_boosted": 1757,
-            "perfect_cp_boosted": 1757
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Slowpoke",
-            "id": "079",
-            "types": [
-                "Water",
-                "Psychic"
-            ],
-            "perfect_cp": 700,
-            "perfect_boosted": 876,
-            "perfect_cp_boosted": 876
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Slowbro",
-            "id": "080",
-            "raid_level": 2,
-            "perfect_cp": 1454,
-            "perfect_cp_boosted": 1817,
-            "types": [
-                "Water",
-                "Psychic"
-            ],
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "perfect_boosted": 1817
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Magnemite",
-            "id": "081",
-            "types": [
-                "Electric",
-                "Steel"
-            ],
-            "raid_level": 1,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "perfect_cp": 778,
-            "perfect_boosted": 973,
-            "perfect_cp_boosted": 973
-        },
-        "availability_rules": []
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Magneton",
-            "id": "082",
-            "raid_level": 2,
-            "perfect_cp": 1420,
-            "perfect_cp_boosted": 1775,
-            "types": [
-                "Electric",
-                "Steel"
-            ],
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "perfect_boosted": 1775
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Farfetch'd",
-            "id": "083",
-            "types": [
-                "Normal",
-                "Flying"
-            ],
-            "perfect_cp": 706,
-            "perfect_boosted": 883,
-            "perfect_cp_boosted": 883
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Doduo",
-            "id": "084",
-            "types": [
-                "Normal",
-                "Flying"
-            ],
-            "perfect_cp": 686,
-            "perfect_boosted": 857,
-            "perfect_cp_boosted": 857
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Dodrio",
-            "id": "085",
-            "types": [
-                "Normal",
-                "Flying"
-            ],
-            "perfect_cp": 1349,
-            "perfect_boosted": 1687,
-            "perfect_cp_boosted": 1687
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Seel",
-            "id": "086",
-            "types": [
-                "Water"
-            ],
-            "perfect_cp": 555,
-            "perfect_boosted": 694,
-            "perfect_cp_boosted": 694
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Dewgong",
-            "id": "087",
-            "types": [
-                "Water",
-                "Ice"
-            ],
-            "perfect_cp": 1134,
-            "perfect_boosted": 1418,
-            "perfect_cp_boosted": 1418,
-            "raid_level": 2,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Grimer",
-            "id": "088",
-            "types": [
-                "Poison",
-                "Dark"
-            ],
-            "perfect_cp": 785,
-            "perfect_boosted": 981,
-            "perfect_cp_boosted": 981
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Muk",
-            "id": "089",
-            "raid_level": 2,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Poison",
-                "Dark"
-            ],
-            "perfect_cp": 1575,
-            "perfect_boosted": 1969,
-            "perfect_cp_boosted": 1969
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Shellder",
-            "id": "090",
-            "raid_level": 1,
-            "perfect_cp": 617,
-            "perfect_cp_boosted": 771,
-            "shiny": true,
-            "types": [
-                "Water"
-            ],
-            "perfect_boosted": 771,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Cloyster",
-            "id": "091",
-            "types": [
-                "Water",
-                "Ice"
-            ],
-            "perfect_cp": 1455,
-            "perfect_boosted": 1819,
-            "perfect_cp_boosted": 1819
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Gastly",
-            "id": "092",
-            "types": [
-                "Ghost",
-                "Poison"
-            ],
-            "perfect_cp": 702,
-            "perfect_boosted": 878,
-            "perfect_cp_boosted": 878
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Haunter",
-            "id": "093",
-            "types": [
-                "Ghost",
-                "Poison"
-            ],
-            "perfect_cp": 1121,
-            "perfect_boosted": 1402,
-            "perfect_cp_boosted": 1402
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Gengar",
-            "id": "094",
-            "raid_level": 3,
-            "types": [
-                "Ghost",
-                "Poison"
-            ],
-            "perfect_cp": 1644,
-            "perfect_boosted": 2055,
-            "perfect_cp_boosted": 2055,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Onix",
-            "id": "095",
-            "raid_level": 3,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Rock",
-                "Ground"
-            ],
-            "perfect_cp": 629,
-            "perfect_boosted": 787,
-            "perfect_cp_boosted": 787
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Drowzee",
-            "id": "096",
-            "raid_level": 1,
-            "types": [
-                "Psychic"
-            ],
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "perfect_cp": 594,
-            "perfect_boosted": 743,
-            "perfect_cp_boosted": 743
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Hypno",
-            "id": "097",
-            "types": [
-                "Psychic"
-            ],
-            "perfect_cp": 1194,
-            "perfect_boosted": 1493,
-            "perfect_cp_boosted": 1493
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Krabby",
-            "id": "098",
-            "types": [
-                "Water"
-            ],
-            "perfect_cp": 892,
-            "perfect_boosted": 1115,
-            "perfect_cp_boosted": 1115
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Kingler",
-            "id": "099",
-            "types": [
-                "Water"
-            ],
-            "perfect_cp": 1616,
-            "perfect_boosted": 2020,
-            "perfect_cp_boosted": 2020
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Voltorb",
-            "id": "100",
-            "types": [
-                "Electric"
-            ],
-            "perfect_cp": 577,
-            "perfect_boosted": 721,
-            "perfect_cp_boosted": 721
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Electrode",
-            "id": "101",
-            "types": [
-                "Electric"
-            ],
-            "perfect_cp": 1199,
-            "perfect_boosted": 1499,
-            "perfect_cp_boosted": 1499
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Exeggcute",
-            "id": "102",
-            "types": [
-                "Grass",
-                "Psychic"
-            ],
-            "perfect_cp": 671,
-            "perfect_boosted": 839,
-            "perfect_cp_boosted": 839
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Exeggutor",
-            "id": "103",
-            "raid_level": 2,
-            "perfect_cp": 1722,
-            "perfect_cp_boosted": 2153,
-            "types": [
-                "Grass",
-                "Dragon"
-            ],
-            "perfect_boosted": 2153,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Cubone",
-            "id": "104",
-            "types": [
-                "Ground"
-            ],
-            "perfect_cp": 582,
-            "perfect_boosted": 728,
-            "perfect_cp_boosted": 728
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Marowak",
-            "id": "105",
-            "raid_level": 4,
-            "perfect_cp": 1048,
-            "perfect_cp_boosted": 1311,
-            "types": [
-                "Fire",
-                "Ghost"
-            ],
-            "perfect_boosted": 1311,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Hitmonlee",
-            "id": "106",
-            "raid_level": 3,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Fighting"
-            ],
-            "perfect_cp": 1472,
-            "perfect_boosted": 1840,
-            "perfect_cp_boosted": 1840
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Hitmonchan",
-            "id": "107",
-            "raid_level": 3,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Fighting"
-            ],
-            "perfect_cp": 1332,
-            "perfect_boosted": 1665,
-            "perfect_cp_boosted": 1665
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Lickitung",
-            "id": "108",
-            "raid_level": 2,
-            "perfect_cp": 806,
-            "perfect_cp_boosted": 1008,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Normal"
-            ],
-            "perfect_boosted": 1008
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Koffing",
-            "id": "109",
-            "types": [
-                "Poison"
-            ],
-            "perfect_cp": 694,
-            "perfect_boosted": 867,
-            "perfect_cp_boosted": 867
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Weezing",
-            "id": "110",
-            "raid_level": 2,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Poison"
-            ],
-            "perfect_cp": 1310,
-            "perfect_boosted": 1637,
-            "perfect_cp_boosted": 1637
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Rhyhorn",
-            "id": "111",
-            "types": [
-                "Ground",
-                "Rock"
-            ],
-            "perfect_cp": 943,
-            "perfect_boosted": 1179,
-            "perfect_cp_boosted": 1179
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Rhydon",
-            "id": "112",
-            "raid_level": 4,
-            "types": [
-                "Ground",
-                "Rock"
-            ],
-            "perfect_cp": 1816,
-            "perfect_boosted": 2270,
-            "perfect_cp_boosted": 2270,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Chansey",
-            "id": "113",
-            "types": [
-                "Normal"
-            ],
-            "perfect_cp": 717,
-            "perfect_boosted": 896,
-            "perfect_cp_boosted": 896
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Tangela",
-            "id": "114",
-            "raid_level": 3,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "perfect_cp": 1278,
-            "perfect_cp_boosted": 1598,
-            "types": [
-                "Grass"
-            ],
-            "perfect_boosted": 1598
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Kangaskhan",
-            "id": "115",
-            "types": [
-                "Normal"
-            ],
-            "perfect_cp": 1477,
-            "perfect_boosted": 1847,
-            "perfect_cp_boosted": 1847
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Horsea",
-            "id": "116",
-            "types": [
-                "Water"
-            ],
-            "perfect_cp": 603,
-            "perfect_boosted": 754,
-            "perfect_cp_boosted": 754
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Seadra",
-            "id": "117",
-            "types": [
-                "Water"
-            ],
-            "perfect_cp": 1196,
-            "perfect_boosted": 1495,
-            "perfect_cp_boosted": 1495
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Goldeen",
-            "id": "118",
-            "types": [
-                "Water"
-            ],
-            "perfect_cp": 658,
-            "perfect_boosted": 823,
-            "perfect_cp_boosted": 823
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Seaking",
-            "id": "119",
-            "types": [
-                "Water"
-            ],
-            "perfect_cp": 1235,
-            "perfect_boosted": 1544,
-            "perfect_cp_boosted": 1544
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Staryu",
-            "id": "120",
-            "types": [
-                "Water"
-            ],
-            "perfect_cp": 661,
-            "perfect_boosted": 826,
-            "perfect_cp_boosted": 826
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Starmie",
-            "id": "121",
-            "raid_level": 3,
-            "perfect_cp": 1476,
-            "perfect_cp_boosted": 1846,
-            "types": [
-                "Water",
-                "Psychic"
-            ],
-            "perfect_boosted": 1846,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Mr. Mime",
-            "id": "122",
-            "types": [
-                "Psychic",
-                "Fairy"
-            ],
-            "perfect_cp": 1273,
-            "perfect_boosted": 1591,
-            "perfect_cp_boosted": 1591
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Scyther",
-            "id": "123",
-            "raid_level": 3,
-            "types": [
-                "Bug",
-                "Flying"
-            ],
-            "perfect_cp": 1546,
-            "perfect_boosted": 1933,
-            "perfect_cp_boosted": 1933,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Jynx",
-            "id": "124",
-            "raid_level": 3,
-            "types": [
-                "Ice",
-                "Psychic"
-            ],
-            "perfect_cp": 1460,
-            "perfect_boosted": 1825,
-            "perfect_cp_boosted": 1825,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Electabuzz",
-            "id": "125",
-            "raid_level": 2,
-            "perfect_cp": 1333,
-            "perfect_cp_boosted": 1667,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Electric"
-            ],
-            "perfect_boosted": 1667
-        },
-        "availability_rules": []
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Magmar",
-            "id": "126",
-            "raid_level": 2,
-            "types": [
-                "Fire"
-            ],
-            "perfect_cp": 1367,
-            "perfect_cp_boosted": 1710,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "perfect_boosted": 1710
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Pinsir",
-            "id": "127",
-            "raid_level": 3,
-            "types": [
-                "Bug"
-            ],
-            "perfect_cp": 1690,
-            "perfect_boosted": 2113,
-            "perfect_cp_boosted": 2113,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Tauros",
-            "id": "128",
-            "types": [
-                "Normal"
-            ],
-            "perfect_cp": 1497,
-            "perfect_boosted": 1872,
-            "perfect_cp_boosted": 1872
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Magikarp",
-            "id": "129",
-            "raid_level": 1,
-            "perfect_cp": 157,
-            "perfect_cp_boosted": 196,
-            "shiny": true,
-            "types": [
-                "Water"
-            ],
-            "perfect_boosted": 196,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Gyarados",
-            "id": "130",
-            "types": [
-                "Water",
-                "Flying"
-            ],
-            "perfect_cp": 1937,
-            "perfect_boosted": 2422,
-            "perfect_cp_boosted": 2422
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Lapras",
-            "id": "131",
-            "raid_level": 4,
-            "types": [
-                "Water",
-                "Ice"
-            ],
-            "perfect_cp": 1509,
-            "perfect_boosted": 1886,
-            "perfect_cp_boosted": 1886,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Ditto",
-            "id": "132",
-            "types": [
-                "Normal"
-            ],
-            "perfect_cp": 475,
-            "perfect_boosted": 594,
-            "perfect_cp_boosted": 594
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Eevee",
-            "id": "133",
-            "types": [
-                "Normal"
-            ],
-            "perfect_cp": 612,
-            "perfect_boosted": 765,
-            "perfect_cp_boosted": 765
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Vaporeon",
-            "id": "134",
-            "raid_level": 3,
-            "perfect_cp": 1779,
-            "perfect_cp_boosted": 2225,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Water"
-            ],
-            "perfect_boosted": 2225
-        },
-        "availability_rules": []
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Jolteon",
-            "id": "135",
-            "raid_level": 3,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Electric"
-            ],
-            "perfect_cp": 1650,
-            "perfect_boosted": 2063,
-            "perfect_cp_boosted": 2063
-        },
-        "availability_rules": []
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Flareon",
-            "id": "136",
-            "raid_level": 3,
-            "types": [
-                "Fire"
-            ],
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "perfect_cp": 1730,
-            "perfect_boosted": 2163,
-            "perfect_cp_boosted": 2163
-        },
-        "availability_rules": []
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Porygon",
-            "id": "137",
-            "raid_level": 3,
-            "types": [
-                "Normal"
-            ],
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "perfect_cp": 982,
-            "perfect_boosted": 1228,
-            "perfect_cp_boosted": 1228
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Omanyte",
-            "id": "138",
-            "raid_level": 1,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "perfect_cp": 882,
-            "perfect_cp_boosted": 1103,
-            "shiny": true,
-            "types": [
-                "Rock",
-                "Water"
-            ],
-            "perfect_boosted": 1103
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Omastar",
-            "id": "139",
-            "raid_level": 3,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Rock",
-                "Water"
-            ],
-            "perfect_cp": 1592,
-            "perfect_boosted": 1990,
-            "perfect_cp_boosted": 1990
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Kabuto",
-            "id": "140",
-            "perfect_cp": 783,
-            "perfect_cp_boosted": 979,
-            "shiny": true,
-            "raid_level": 1,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Rock",
-                "Water"
-            ],
-            "perfect_boosted": 979
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Kabutops",
-            "id": "141",
-            "raid_level": 3,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Rock",
-                "Water"
-            ],
-            "perfect_cp": 1550,
-            "perfect_boosted": 1938,
-            "perfect_cp_boosted": 1938
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Aerodactyl",
-            "id": "142",
-            "raid_level": 3,
-            "shiny": true,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Rock",
-                "Flying"
-            ],
-            "perfect_cp": 1590,
-            "perfect_boosted": 1988,
-            "perfect_cp_boosted": 1988
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Snorlax",
-            "id": "143",
-            "raid_level": 4,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Normal"
-            ],
-            "perfect_cp": 1843,
-            "perfect_boosted": 2304,
-            "perfect_cp_boosted": 2304
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Articuno",
-            "id": "144",
-            "raid_level": 5,
-            "shiny": true,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Ice",
-                "Flying"
-            ],
-            "perfect_cp": 1743,
-            "perfect_boosted": 2179,
-            "perfect_cp_boosted": 2179
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Zapdos",
-            "id": "145",
-            "raid_level": 5,
-            "shiny": true,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Electric",
-                "Flying"
-            ],
-            "perfect_cp": 2015,
-            "perfect_boosted": 2519,
-            "perfect_cp_boosted": 2519
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Moltres",
-            "id": "146",
-            "raid_level": 5,
-            "shiny": true,
-            "perfect_cp": 1980,
-            "perfect_cp_boosted": 2475,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Fire",
-                "Flying"
-            ],
-            "perfect_boosted": 2475
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Dratini",
-            "id": "147",
-            "types": [
-                "Dragon"
-            ],
-            "shiny": true,
-            "raid_level": 1,
-            "perfect_cp": 574,
-            "perfect_cp_boosted": 717,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "perfect_boosted": 717
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Dragonair",
-            "id": "148",
-            "types": [
-                "Dragon"
-            ],
-            "perfect_cp": 1017,
-            "perfect_boosted": 1271,
-            "perfect_cp_boosted": 1271
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Dragonite",
-            "id": "149",
-            "types": [
-                "Dragon",
-                "Flying"
-            ],
-            "perfect_cp": 2167,
-            "perfect_boosted": 2709,
-            "perfect_cp_boosted": 2709
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Mewtwo",
-            "id": "150",
-            "raid_level": 5,
-            "shiny": false,
-            "perfect_cp": 2387,
-            "perfect_cp_boosted": 2984,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Psychic"
-            ],
-            "perfect_boosted": 2984
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Mew",
-            "id": "151",
-            "types": [
-                "Psychic"
-            ],
-            "perfect_cp": 1865,
-            "perfect_boosted": 2332,
-            "perfect_cp_boosted": 2332
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Chikorita",
-            "id": "152",
-            "types": [
-                "Grass"
-            ],
-            "perfect_cp": 534,
-            "perfect_boosted": 668,
-            "perfect_cp_boosted": 668
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Bayleef",
-            "id": "153",
-            "types": [
-                "Grass"
-            ],
-            "perfect_cp": 831,
-            "perfect_boosted": 1039,
-            "perfect_cp_boosted": 1039
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Meganium",
-            "id": "154",
-            "types": [
-                "Grass"
-            ],
-            "perfect_cp": 1377,
-            "perfect_boosted": 1721,
-            "perfect_cp_boosted": 1721
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Cyndaquil",
-            "id": "155",
-            "types": [
-                "Fire"
-            ],
-            "perfect_cp": 560,
-            "perfect_boosted": 700,
-            "perfect_cp_boosted": 700
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Quilava",
-            "id": "156",
-            "types": [
-                "Fire"
-            ],
-            "perfect_cp": 944,
-            "perfect_boosted": 1180,
-            "perfect_cp_boosted": 1180
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Typhlosion",
-            "id": "157",
-            "types": [
-                "Fire"
-            ],
-            "perfect_cp": 1651,
-            "perfect_boosted": 2064,
-            "perfect_cp_boosted": 2064
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Totodile",
-            "id": "158",
-            "types": [
-                "Water"
-            ],
-            "perfect_cp": 646,
-            "perfect_boosted": 808,
-            "perfect_cp_boosted": 808
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Croconaw",
-            "id": "159",
-            "raid_level": 2,
-            "perfect_cp": 984,
-            "perfect_cp_boosted": 1230,
-            "types": [
-                "Water"
-            ],
-            "perfect_boosted": 1230,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Feraligatr",
-            "id": "160",
-            "types": [
-                "Water"
-            ],
-            "perfect_cp": 1632,
-            "perfect_boosted": 2040,
-            "perfect_cp_boosted": 2040
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Sentret",
-            "id": "161",
-            "types": [
-                "Normal"
-            ],
-            "perfect_cp": 353,
-            "perfect_boosted": 441,
-            "perfect_cp_boosted": 441
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Furret",
-            "id": "162",
-            "types": [
-                "Normal"
-            ],
-            "perfect_cp": 1004,
-            "perfect_boosted": 1255,
-            "perfect_cp_boosted": 1255
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Hoothoot",
-            "id": "163",
-            "types": [
-                "Normal",
-                "Flying"
-            ],
-            "perfect_cp": 387,
-            "perfect_boosted": 484,
-            "perfect_cp_boosted": 484
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Noctowl",
-            "id": "164",
-            "types": [
-                "Normal",
-                "Flying"
-            ],
-            "perfect_cp": 1156,
-            "perfect_boosted": 1446,
-            "perfect_cp_boosted": 1446
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Ledyba",
-            "id": "165",
-            "types": [
-                "Bug",
-                "Flying"
-            ],
-            "perfect_cp": 416,
-            "perfect_boosted": 520,
-            "perfect_cp_boosted": 520
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Ledian",
-            "id": "166",
-            "types": [
-                "Bug",
-                "Flying"
-            ],
-            "perfect_cp": 769,
-            "perfect_boosted": 961,
-            "perfect_cp_boosted": 961
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Spinarak",
-            "id": "167",
-            "types": [
-                "Bug",
-                "Poison"
-            ],
-            "perfect_cp": 466,
-            "perfect_boosted": 583,
-            "perfect_cp_boosted": 583
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Ariados",
-            "id": "168",
-            "types": [
-                "Bug",
-                "Poison"
-            ],
-            "perfect_cp": 1012,
-            "perfect_boosted": 1265,
-            "perfect_cp_boosted": 1265
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Crobat",
-            "id": "169",
-            "types": [
-                "Poison",
-                "Flying"
-            ],
-            "perfect_cp": 1512,
-            "perfect_boosted": 1890,
-            "perfect_cp_boosted": 1890
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Chinchou",
-            "id": "170",
-            "types": [
-                "Water",
-                "Electric"
-            ],
-            "perfect_cp": 639,
-            "perfect_boosted": 799,
-            "perfect_cp_boosted": 799
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Lanturn",
-            "id": "171",
-            "types": [
-                "Water",
-                "Electric"
-            ],
-            "perfect_cp": 1191,
-            "perfect_boosted": 1489,
-            "perfect_cp_boosted": 1489,
-            "raid_level": 2,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        },
-        "availability_rules": []
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Pichu",
-            "id": "172",
-            "types": [
-                "Electric"
-            ],
-            "perfect_cp": 270,
-            "perfect_boosted": 338,
-            "perfect_cp_boosted": 338
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Cleffa",
-            "id": "173",
-            "types": [
-                "Fairy"
-            ],
-            "perfect_cp": 383,
-            "perfect_boosted": 479,
-            "perfect_cp_boosted": 479
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Igglybuff",
-            "id": "174",
-            "types": [
-                "Normal",
-                "Fairy"
-            ],
-            "perfect_cp": 306,
-            "perfect_boosted": 382,
-            "perfect_cp_boosted": 382
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Togepi",
-            "id": "175",
-            "types": [
-                "Fairy"
-            ],
-            "perfect_cp": 375,
-            "perfect_boosted": 470,
-            "perfect_cp_boosted": 470
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Togetic",
-            "id": "176",
-            "raid_level": 4,
-            "types": [
-                "Fairy",
-                "Flying"
-            ],
-            "perfect_cp": 976,
-            "perfect_boosted": 1220,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "perfect_cp_boosted": 1220
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Natu",
-            "id": "177",
-            "types": [
-                "Psychic",
-                "Flying"
-            ],
-            "perfect_cp": 630,
-            "perfect_boosted": 787,
-            "perfect_cp_boosted": 787
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Xatu",
-            "id": "178",
-            "types": [
-                "Psychic",
-                "Flying"
-            ],
-            "perfect_cp": 1250,
-            "perfect_boosted": 1563,
-            "perfect_cp_boosted": 1563
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Mareep",
-            "id": "179",
-            "types": [
-                "Electric"
-            ],
-            "perfect_cp": 566,
-            "perfect_boosted": 708,
-            "perfect_cp_boosted": 708,
-            "raid_level": 1,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        },
-        "availability_rules": []
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Flaaffy",
-            "id": "180",
-            "types": [
-                "Electric"
-            ],
-            "perfect_cp": 869,
-            "perfect_boosted": 1086,
-            "perfect_cp_boosted": 1086
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Ampharos",
-            "id": "181",
-            "types": [
-                "Electric"
-            ],
-            "perfect_cp": 1630,
-            "perfect_boosted": 2037,
-            "perfect_cp_boosted": 2037
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Bellossom",
-            "id": "182",
-            "types": [
-                "Grass"
-            ],
-            "perfect_cp": 1303,
-            "perfect_boosted": 1629,
-            "perfect_cp_boosted": 1629
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Marill",
-            "id": "183",
-            "types": [
-                "Water",
-                "Fairy"
-            ],
-            "perfect_cp": 263,
-            "perfect_boosted": 329,
-            "perfect_cp_boosted": 329
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Azumarill",
-            "id": "184",
-            "types": [
-                "Water",
-                "Fairy"
-            ],
-            "perfect_cp": 907,
-            "perfect_boosted": 1134,
-            "perfect_cp_boosted": 1134
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Sudowoodo",
-            "id": "185",
-            "raid_level": 2,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Rock"
-            ],
-            "perfect_cp": 1227,
-            "perfect_boosted": 1534,
-            "perfect_cp_boosted": 1534
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Politoed",
-            "id": "186",
-            "types": [
-                "Water"
-            ],
-            "perfect_cp": 1399,
-            "perfect_boosted": 1749,
-            "perfect_cp_boosted": 1749
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Hoppip",
-            "id": "187",
-            "types": [
-                "Grass",
-                "Flying"
-            ],
-            "perfect_cp": 342,
-            "perfect_boosted": 428,
-            "perfect_cp_boosted": 428
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Skiploom",
-            "id": "188",
-            "types": [
-                "Grass",
-                "Flying"
-            ],
-            "perfect_cp": 557,
-            "perfect_boosted": 697,
-            "perfect_cp_boosted": 697
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Jumpluff",
-            "id": "189",
-            "types": [
-                "Grass",
-                "Flying"
-            ],
-            "perfect_cp": 935,
-            "perfect_boosted": 1168,
-            "perfect_cp_boosted": 1168
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Aipom",
-            "id": "190",
-            "types": [
-                "Normal"
-            ],
-            "perfect_cp": 770,
-            "perfect_boosted": 963,
-            "perfect_cp_boosted": 963
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Sunkern",
-            "id": "191",
-            "types": [
-                "Grass"
-            ],
-            "perfect_cp": 226,
-            "perfect_boosted": 282,
-            "perfect_cp_boosted": 282
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Sunflora",
-            "id": "192",
-            "types": [
-                "Grass"
-            ],
-            "perfect_cp": 1223,
-            "perfect_boosted": 1529,
-            "perfect_cp_boosted": 1529
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Yanma",
-            "id": "193",
-            "types": [
-                "Bug",
-                "Flying"
-            ],
-            "perfect_cp": 840,
-            "perfect_boosted": 1050,
-            "perfect_cp_boosted": 1050
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Wooper",
-            "id": "194",
-            "types": [
-                "Water",
-                "Ground"
-            ],
-            "perfect_cp": 366,
-            "perfect_boosted": 458,
-            "perfect_cp_boosted": 458
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Quagsire",
-            "id": "195",
-            "types": [
-                "Water",
-                "Ground"
-            ],
-            "perfect_cp": 1138,
-            "perfect_boosted": 1423,
-            "perfect_cp_boosted": 1423
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Espeon",
-            "id": "196",
-            "types": [
-                "Psychic"
-            ],
-            "perfect_cp": 1811,
-            "perfect_boosted": 2264,
-            "perfect_cp_boosted": 2264,
-            "raid_level": 3,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        },
-        "availability_rules": []
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Umbreon",
-            "id": "197",
-            "types": [
-                "Dark"
-            ],
-            "perfect_cp": 1221,
-            "perfect_boosted": 1526,
-            "perfect_cp_boosted": 1526,
-            "raid_level": 3,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        },
-        "availability_rules": []
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Murkrow",
-            "id": "198",
-            "types": [
-                "Dark",
-                "Flying"
-            ],
-            "perfect_cp": 892,
-            "perfect_boosted": 1116,
-            "perfect_cp_boosted": 1116
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Slowking",
-            "id": "199",
-            "types": [
-                "Water",
-                "Psychic"
-            ],
-            "perfect_cp": 1454,
-            "perfect_boosted": 1817,
-            "perfect_cp_boosted": 1817
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Misdreavus",
-            "id": "200",
-            "raid_level": 2,
-            "types": [
-                "Ghost"
-            ],
-            "perfect_cp": 1100,
-            "perfect_boosted": 1376,
-            "perfect_cp_boosted": 1376,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Unown",
-            "id": "201",
-            "types": [
-                "Psychic"
-            ],
-            "perfect_cp": 677,
-            "perfect_boosted": 846,
-            "perfect_cp_boosted": 846
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Wobbuffet",
-            "id": "202",
-            "types": [
-                "Psychic"
-            ],
-            "perfect_cp": 586,
-            "perfect_boosted": 733,
-            "perfect_cp_boosted": 733
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Girafarig",
-            "id": "203",
-            "types": [
-                "Normal",
-                "Psychic"
-            ],
-            "perfect_cp": 1169,
-            "perfect_boosted": 1462,
-            "perfect_cp_boosted": 1462
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Pineco",
-            "id": "204",
-            "types": [
-                "Bug"
-            ],
-            "perfect_cp": 633,
-            "perfect_boosted": 791,
-            "perfect_cp_boosted": 791
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Forretress",
-            "id": "205",
-            "types": [
-                "Bug",
-                "Steel"
-            ],
-            "perfect_cp": 1304,
-            "perfect_boosted": 1630,
-            "perfect_cp_boosted": 1630
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Dunsparce",
-            "id": "206",
-            "types": [
-                "Normal"
-            ],
-            "perfect_cp": 965,
-            "perfect_boosted": 1206,
-            "perfect_cp_boosted": 1206
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Gligar",
-            "id": "207",
-            "types": [
-                "Ground",
-                "Flying"
-            ],
-            "perfect_cp": 1061,
-            "perfect_boosted": 1326,
-            "perfect_cp_boosted": 1326
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Steelix",
-            "id": "208",
-            "types": [
-                "Steel",
-                "Ground"
-            ],
-            "perfect_cp": 1379,
-            "perfect_boosted": 1724,
-            "perfect_cp_boosted": 1724
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Snubbull",
-            "id": "209",
-            "types": [
-                "Fairy"
-            ],
-            "perfect_cp": 707,
-            "perfect_boosted": 884,
-            "perfect_cp_boosted": 884
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Granbull",
-            "id": "210",
-            "raid_level": 3,
-            "types": [
-                "Fairy"
-            ],
-            "perfect_cp": 1458,
-            "perfect_boosted": 1823,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "perfect_cp_boosted": 1823
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Qwilfish",
-            "id": "211",
-            "types": [
-                "Water",
-                "Poison"
-            ],
-            "perfect_cp": 1172,
-            "perfect_boosted": 1465,
-            "perfect_cp_boosted": 1465
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Scizor",
-            "id": "212",
-            "types": [
-                "Bug",
-                "Steel"
-            ],
-            "perfect_cp": 1714,
-            "perfect_boosted": 2143,
-            "perfect_cp_boosted": 2143
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Shuckle",
-            "id": "213",
-            "types": [
-                "Bug",
-                "Rock"
-            ],
-            "perfect_cp": 231,
-            "perfect_boosted": 289,
-            "perfect_cp_boosted": 289
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Heracross",
-            "id": "214",
-            "types": [
-                "Bug",
-                "Fighting"
-            ],
-            "perfect_cp": 1772,
-            "perfect_boosted": 2215,
-            "perfect_cp_boosted": 2215
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Sneasel",
-            "id": "215",
-            "raid_level": 2,
-            "types": [
-                "Dark",
-                "Ice"
-            ],
-            "perfect_cp": 1172,
-            "perfect_boosted": 1465,
-            "perfect_cp_boosted": 1465,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Teddiursa",
-            "id": "216",
-            "types": [
-                "Normal"
-            ],
-            "perfect_cp": 759,
-            "perfect_boosted": 949,
-            "perfect_cp_boosted": 949
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Ursaring",
-            "id": "217",
-            "types": [
-                "Normal"
-            ],
-            "perfect_cp": 1682,
-            "perfect_boosted": 2103,
-            "perfect_cp_boosted": 2103
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Slugma",
-            "id": "218",
-            "types": [
-                "Fire"
-            ],
-            "perfect_cp": 511,
-            "perfect_boosted": 639,
-            "perfect_cp_boosted": 639
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Magcargo",
-            "id": "219",
-            "types": [
-                "Fire",
-                "Rock"
-            ],
-            "perfect_cp": 972,
-            "perfect_boosted": 1215,
-            "perfect_cp_boosted": 1215
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Swinub",
-            "id": "220",
-            "types": [
-                "Ice",
-                "Ground"
-            ],
-            "perfect_cp": 423,
-            "perfect_boosted": 529,
-            "perfect_cp_boosted": 529
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Piloswine",
-            "id": "221",
-            "raid_level": 3,
-            "types": [
-                "Ice",
-                "Ground"
-            ],
-            "perfect_cp": 1340,
-            "perfect_boosted": 1675,
-            "perfect_cp_boosted": 1675,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Corsola",
-            "id": "222",
-            "types": [
-                "Water",
-                "Rock"
-            ],
-            "perfect_cp": 787,
-            "perfect_boosted": 984,
-            "perfect_cp_boosted": 984
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Remoraid",
-            "id": "223",
-            "types": [
-                "Water"
-            ],
-            "perfect_cp": 521,
-            "perfect_boosted": 651,
-            "perfect_cp_boosted": 651
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Octillery",
-            "id": "224",
-            "types": [
-                "Water"
-            ],
-            "perfect_cp": 1322,
-            "perfect_boosted": 1653,
-            "perfect_cp_boosted": 1653
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Delibird",
-            "id": "225",
-            "types": [
-                "Ice",
-                "Flying"
-            ],
-            "perfect_cp": 625,
-            "perfect_boosted": 781,
-            "perfect_cp_boosted": 781
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Mantine",
-            "id": "226",
-            "types": [
-                "Water",
-                "Flying"
-            ],
-            "perfect_cp": 1204,
-            "perfect_boosted": 1506,
-            "perfect_cp_boosted": 1506
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Skarmory",
-            "id": "227",
-            "types": [
-                "Steel",
-                "Flying"
-            ],
-            "perfect_cp": 1204,
-            "perfect_boosted": 1506,
-            "perfect_cp_boosted": 1506
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Houndour",
-            "id": "228",
-            "types": [
-                "Dark",
-                "Fire"
-            ],
-            "perfect_cp": 705,
-            "perfect_boosted": 881,
-            "perfect_cp_boosted": 881
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Houndoom",
-            "id": "229",
-            "raid_level": 4,
-            "types": [
-                "Dark",
-                "Fire"
-            ],
-            "perfect_cp": 1505,
-            "perfect_boosted": 1882,
-            "perfect_cp_boosted": 1882,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Kingdra",
-            "id": "230",
-            "types": [
-                "Water",
-                "Dragon"
-            ],
-            "perfect_cp": 1509,
-            "perfect_boosted": 1887,
-            "perfect_cp_boosted": 1887
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Phanpy",
-            "id": "231",
-            "types": [
-                "Ground"
-            ],
-            "perfect_cp": 689,
-            "perfect_boosted": 862,
-            "perfect_cp_boosted": 862
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Donphan",
-            "id": "232",
-            "raid_level": 3,
-            "types": [
-                "Ground"
-            ],
-            "perfect_cp": 1722,
-            "perfect_boosted": 2152,
-            "perfect_cp_boosted": 2152,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Porygon2",
-            "id": "233",
-            "types": [
-                "Normal"
-            ],
-            "perfect_cp": 1549,
-            "perfect_boosted": 1936,
-            "perfect_cp_boosted": 1936
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Stantler",
-            "id": "234",
-            "types": [
-                "Normal"
-            ],
-            "perfect_cp": 1236,
-            "perfect_boosted": 1546,
-            "perfect_cp_boosted": 1546
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Smeargle",
-            "id": "235",
-            "types": [
-                "Normal"
-            ],
-            "perfect_cp": 246,
-            "perfect_boosted": 308,
-            "perfect_cp_boosted": 308
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Tyrogue",
-            "id": "236",
-            "types": [
-                "Fighting"
-            ],
-            "perfect_cp": 281,
-            "perfect_boosted": 351,
-            "perfect_cp_boosted": 351
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Hitmontop",
-            "id": "237",
-            "types": [
-                "Fighting"
-            ],
-            "perfect_cp": 1232,
-            "perfect_boosted": 1540,
-            "perfect_cp_boosted": 1540
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Smoochum",
-            "id": "238",
-            "types": [
-                "Ice",
-                "Psychic"
-            ],
-            "perfect_cp": 738,
-            "perfect_boosted": 922,
-            "perfect_cp_boosted": 922
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Elekid",
-            "id": "239",
-            "types": [
-                "Electric"
-            ],
-            "perfect_cp": 689,
-            "perfect_boosted": 861,
-            "perfect_cp_boosted": 861
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Magby",
-            "id": "240",
-            "types": [
-                "Fire"
-            ],
-            "perfect_cp": 756,
-            "perfect_boosted": 945,
-            "perfect_cp_boosted": 945
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Miltank",
-            "id": "241",
-            "types": [
-                "Normal"
-            ],
-            "perfect_cp": 1345,
-            "perfect_boosted": 1682,
-            "perfect_cp_boosted": 1682
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Blissey",
-            "id": "242",
-            "types": [
-                "Normal"
-            ],
-            "perfect_cp": 1575,
-            "perfect_boosted": 1969,
-            "perfect_cp_boosted": 1969
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Raikou",
-            "id": "243",
-            "raid_level": 5,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Electric"
-            ],
-            "perfect_cp": 1972,
-            "perfect_boosted": 2466,
-            "perfect_cp_boosted": 2466
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Entei",
-            "id": "244",
-            "raid_level": 5,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Fire"
-            ],
-            "perfect_cp": 1984,
-            "perfect_boosted": 2480,
-            "perfect_cp_boosted": 2480
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Suicune",
-            "id": "245",
-            "raid_level": 5,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Water"
-            ],
-            "perfect_cp": 1704,
-            "perfect_boosted": 2130,
-            "perfect_cp_boosted": 2130
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Larvitar",
-            "id": "246",
-            "types": [
-                "Rock",
-                "Ground"
-            ],
-            "perfect_cp": 594,
-            "perfect_boosted": 743,
-            "perfect_cp_boosted": 743
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Pupitar",
-            "id": "247",
-            "types": [
-                "Rock",
-                "Ground"
-            ],
-            "perfect_cp": 1009,
-            "perfect_boosted": 1261,
-            "perfect_cp_boosted": 1261
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Tyranitar",
-            "id": "248",
-            "raid_level": 4,
-            "perfect_cp": 2191,
-            "perfect_cp_boosted": 2739,
-            "types": [
-                "Rock",
-                "Dark"
-            ],
-            "perfect_boosted": 2739,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Lugia",
-            "id": "249",
-            "raid_level": 5,
-            "types": [
-                "Psychic",
-                "Flying"
-            ],
-            "perfect_cp": 2115,
-            "perfect_boosted": 2645,
-            "perfect_cp_boosted": 2645,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Ho-Oh",
-            "id": "250",
-            "raid_level": 5,
-            "types": [
-                "Fire",
-                "Flying"
-            ],
-            "perfect_cp": 2207,
-            "perfect_boosted": 2759,
-            "perfect_cp_boosted": 2759,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Celebi",
-            "id": "251",
-            "types": [
-                "Psychic",
-                "Grass"
-            ],
-            "perfect_cp": 1865,
-            "perfect_boosted": 2332,
-            "perfect_cp_boosted": 2332
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Treecko",
-            "id": "252",
-            "types": [
-                "Grass"
-            ],
-            "perfect_cp": 601,
-            "perfect_boosted": 752,
-            "perfect_cp_boosted": 752
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Grovyle",
-            "id": "253",
-            "types": [
-                "Grass"
-            ],
-            "perfect_cp": 956,
-            "perfect_boosted": 1195,
-            "perfect_cp_boosted": 1195,
-            "raid_level": 2
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Sceptile",
-            "id": "254",
-            "types": [
-                "Grass"
-            ],
-            "perfect_cp": 1575,
-            "perfect_boosted": 1969,
-            "perfect_cp_boosted": 1969
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Torchic",
-            "id": "255",
-            "types": [
-                "Fire"
-            ],
-            "perfect_cp": 624,
-            "perfect_boosted": 781,
-            "perfect_cp_boosted": 781
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Combusken",
-            "id": "256",
-            "raid_level": 2,
-            "types": [
-                "Fire",
-                "Fighting"
-            ],
-            "perfect_cp": 944,
-            "perfect_boosted": 1180,
-            "perfect_cp_boosted": 1180
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Blaziken",
-            "id": "257",
-            "types": [
-                "Fire",
-                "Fighting"
-            ],
-            "perfect_cp": 1627,
-            "perfect_boosted": 2034,
-            "perfect_cp_boosted": 2034
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Mudkip",
-            "id": "258",
-            "types": [
-                "Water"
-            ],
-            "perfect_cp": 644,
-            "perfect_boosted": 805,
-            "perfect_cp_boosted": 805
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Marshtomp",
-            "id": "259",
-            "raid_level": 2,
-            "perfect_cp": 1015,
-            "perfect_cp_boosted": 1269,
-            "shiny": true,
-            "types": [
-                "Water",
-                "Ground"
-            ],
-            "perfect_boosted": 1269
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Swampert",
-            "id": "260",
-            "types": [
-                "Water",
-                "Ground"
-            ],
-            "perfect_cp": 1699,
-            "perfect_boosted": 2124,
-            "perfect_cp_boosted": 2124
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Poochyena",
-            "id": "261",
-            "types": [
-                "Dark"
-            ],
-            "perfect_cp": 387,
-            "perfect_boosted": 484,
-            "perfect_cp_boosted": 484
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Mightyena",
-            "id": "262",
-            "types": [
-                "Dark"
-            ],
-            "perfect_cp": 1100,
-            "perfect_boosted": 1375,
-            "perfect_cp_boosted": 1375
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Zigzagoon",
-            "id": "263",
-            "types": [
-                "Normal"
-            ],
-            "perfect_cp": 290,
-            "perfect_boosted": 363,
-            "perfect_cp_boosted": 363
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Linoone",
-            "id": "264",
-            "types": [
-                "Normal"
-            ],
-            "perfect_cp": 949,
-            "perfect_boosted": 1187,
-            "perfect_cp_boosted": 1187
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Wurmple",
-            "id": "265",
-            "types": [
-                "Bug"
-            ],
-            "perfect_cp": 330,
-            "perfect_boosted": 413,
-            "perfect_cp_boosted": 413
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Silcoon",
-            "id": "266",
-            "types": [
-                "Bug"
-            ],
-            "perfect_cp": 316,
-            "perfect_boosted": 395,
-            "perfect_cp_boosted": 395
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Beautifly",
-            "id": "267",
-            "types": [
-                "Bug",
-                "Flying"
-            ],
-            "perfect_cp": 1009,
-            "perfect_boosted": 1261,
-            "perfect_cp_boosted": 1261
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Cascoon",
-            "id": "268",
-            "types": [
-                "Bug"
-            ],
-            "perfect_cp": 316,
-            "perfect_boosted": 395,
-            "perfect_cp_boosted": 395
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Dustox",
-            "id": "269",
-            "types": [
-                "Bug",
-                "Poison"
-            ],
-            "perfect_cp": 699,
-            "perfect_boosted": 874,
-            "perfect_cp_boosted": 874
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Lotad",
-            "id": "270",
-            "types": [
-                "Water",
-                "Grass"
-            ],
-            "perfect_cp": 342,
-            "perfect_boosted": 427,
-            "perfect_cp_boosted": 427
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Lombre",
-            "id": "271",
-            "types": [
-                "Water",
-                "Grass"
-            ],
-            "perfect_cp": 684,
-            "perfect_boosted": 855,
-            "perfect_cp_boosted": 855
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Ludicolo",
-            "id": "272",
-            "types": [
-                "Water",
-                "Grass"
-            ],
-            "perfect_cp": 1327,
-            "perfect_boosted": 1659,
-            "perfect_cp_boosted": 1659
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Seedot",
-            "id": "273",
-            "types": [
-                "Grass"
-            ],
-            "perfect_cp": 342,
-            "perfect_boosted": 427,
-            "perfect_cp_boosted": 427
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Nuzleaf",
-            "id": "274",
-            "types": [
-                "Grass",
-                "Dark"
-            ],
-            "perfect_cp": 701,
-            "perfect_boosted": 876,
-            "perfect_cp_boosted": 876
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Shiftry",
-            "id": "275",
-            "types": [
-                "Grass",
-                "Dark"
-            ],
-            "perfect_cp": 1333,
-            "perfect_boosted": 1666,
-            "perfect_cp_boosted": 1666,
-            "raid_level": 4
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Taillow",
-            "id": "276",
-            "types": [
-                "Normal",
-                "Flying"
-            ],
-            "perfect_cp": 437,
-            "perfect_boosted": 546,
-            "perfect_cp_boosted": 546
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Swellow",
-            "id": "277",
-            "types": [
-                "Normal",
-                "Flying"
-            ],
-            "perfect_cp": 1097,
-            "perfect_boosted": 1371,
-            "perfect_cp_boosted": 1371
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Wingull",
-            "id": "278",
-            "types": [
-                "Water",
-                "Flying"
-            ],
-            "perfect_cp": 437,
-            "perfect_boosted": 546,
-            "perfect_cp_boosted": 546,
-            "raid_level": 1
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Pelipper",
-            "id": "279",
-            "types": [
-                "Water",
-                "Flying"
-            ],
-            "perfect_cp": 1215,
-            "perfect_boosted": 1519,
-            "perfect_cp_boosted": 1519
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Ralts",
-            "id": "280",
-            "types": [
-                "Psychic",
-                "Fairy"
-            ],
-            "perfect_cp": 308,
-            "perfect_boosted": 385,
-            "perfect_cp_boosted": 385
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Kirlia",
-            "id": "281",
-            "raid_level": 2,
-            "types": [
-                "Psychic",
-                "Fairy"
-            ],
-            "perfect_cp": 552,
-            "perfect_boosted": 690,
-            "perfect_cp_boosted": 690
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Gardevoir",
-            "id": "282",
-            "types": [
-                "Psychic",
-                "Fairy"
-            ],
-            "perfect_cp": 1767,
-            "perfect_boosted": 2209,
-            "perfect_cp_boosted": 2209
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Surskit",
-            "id": "283",
-            "types": [
-                "Bug",
-                "Water"
-            ],
-            "perfect_cp": 452,
-            "perfect_boosted": 565,
-            "perfect_cp_boosted": 565
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Masquerain",
-            "id": "284",
-            "types": [
-                "Bug",
-                "Flying"
-            ],
-            "perfect_cp": 1297,
-            "perfect_boosted": 1622,
-            "perfect_cp_boosted": 1622
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Shroomish",
-            "id": "285",
-            "types": [
-                "Grass"
-            ],
-            "perfect_cp": 463,
-            "perfect_boosted": 578,
-            "perfect_cp_boosted": 578
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Breloom",
-            "id": "286",
-            "raid_level": 2,
-            "types": [
-                "Grass",
-                "Fighting"
-            ],
-            "perfect_cp": 1502,
-            "perfect_boosted": 1877,
-            "perfect_cp_boosted": 1877,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Slakoth",
-            "id": "287",
-            "types": [
-                "Normal"
-            ],
-            "perfect_cp": 572,
-            "perfect_boosted": 716,
-            "perfect_cp_boosted": 716
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Vigoroth",
-            "id": "288",
-            "types": [
-                "Normal"
-            ],
-            "perfect_cp": 1124,
-            "perfect_boosted": 1405,
-            "perfect_cp_boosted": 1405
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Slaking",
-            "id": "289",
-            "types": [
-                "Normal"
-            ],
-            "perfect_cp": 2532,
-            "perfect_boosted": 3165,
-            "perfect_cp_boosted": 3165
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Nincada",
-            "id": "290",
-            "types": [
-                "Bug",
-                "Ground"
-            ],
-            "perfect_cp": 439,
-            "perfect_boosted": 549,
-            "perfect_cp_boosted": 549
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Ninjask",
-            "id": "291",
-            "types": [
-                "Bug",
-                "Flying"
-            ],
-            "perfect_cp": 1109,
-            "perfect_boosted": 1387,
-            "perfect_cp_boosted": 1387
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Shedinja",
-            "id": "292",
-            "types": [
-                "Bug",
-                "Ghost"
-            ],
-            "perfect_cp": 224,
-            "perfect_boosted": 281,
-            "perfect_cp_boosted": 281
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Whismur",
-            "id": "293",
-            "types": [
-                "Normal"
-            ],
-            "perfect_cp": 383,
-            "perfect_boosted": 479,
-            "perfect_cp_boosted": 479
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Loudred",
-            "id": "294",
-            "types": [
-                "Normal"
-            ],
-            "perfect_cp": 758,
-            "perfect_boosted": 948,
-            "perfect_cp_boosted": 948
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Exploud",
-            "id": "295",
-            "types": [
-                "Normal"
-            ],
-            "perfect_cp": 1341,
-            "perfect_boosted": 1677,
-            "perfect_cp_boosted": 1677
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Makuhita",
-            "id": "296",
-            "shiny": true,
-            "raid_level": 1,
-            "types": [
-                "Fighting"
-            ],
-            "perfect_cp": 467,
-            "perfect_boosted": 583,
-            "perfect_cp_boosted": 583,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Hariyama",
-            "id": "297",
-            "types": [
-                "Fighting"
-            ],
-            "perfect_cp": 1616,
-            "perfect_boosted": 2020,
-            "perfect_cp_boosted": 2020
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Azurill",
-            "id": "298",
-            "types": [
-                "Normal",
-                "Fairy"
-            ],
-            "perfect_cp": 208,
-            "perfect_boosted": 260,
-            "perfect_cp_boosted": 260
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Nosepass",
-            "id": "299",
-            "types": [
-                "Rock"
-            ],
-            "perfect_cp": 567,
-            "perfect_boosted": 709,
-            "perfect_cp_boosted": 709
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Skitty",
-            "id": "300",
-            "types": [
-                "Normal"
-            ],
-            "perfect_cp": 422,
-            "perfect_boosted": 527,
-            "perfect_cp_boosted": 527
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Delcatty",
-            "id": "301",
-            "types": [
-                "Normal"
-            ],
-            "perfect_cp": 854,
-            "perfect_boosted": 1068,
-            "perfect_cp_boosted": 1068
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Sableye",
-            "id": "302",
-            "raid_level": 2,
-            "types": [
-                "Dark",
-                "Ghost"
-            ],
-            "perfect_cp": 843,
-            "perfect_boosted": 1054,
-            "perfect_cp_boosted": 1054
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Mawile",
-            "id": "303",
-            "raid_level": 2,
-            "perfect_cp": 934,
-            "perfect_cp_boosted": 1167,
-            "shiny": true,
-            "types": [
-                "Steel",
-                "Fairy"
-            ],
-            "perfect_boosted": 1167
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Aron",
-            "id": "304",
-            "types": [
-                "Steel",
-                "Rock"
-            ],
-            "perfect_cp": 747,
-            "perfect_boosted": 934,
-            "perfect_cp_boosted": 934
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Lairon",
-            "id": "305",
-            "types": [
-                "Steel",
-                "Rock"
-            ],
-            "perfect_cp": 1174,
-            "perfect_boosted": 1468,
-            "perfect_cp_boosted": 1468
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Aggron",
-            "id": "306",
-            "raid_level": 4,
-            "perfect_cp": 1714,
-            "perfect_cp_boosted": 2143,
-            "types": [
-                "Steel",
-                "Rock"
-            ],
-            "perfect_boosted": 2143
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Meditite",
-            "id": "307",
-            "raid_level": 1,
-            "types": [
-                "Fighting",
-                "Psychic"
-            ],
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "perfect_cp": 396,
-            "perfect_boosted": 495,
-            "perfect_cp_boosted": 495
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Medicham",
-            "id": "308",
-            "types": [
-                "Fighting",
-                "Psychic"
-            ],
-            "perfect_cp": 817,
-            "perfect_boosted": 1022,
-            "perfect_cp_boosted": 1022
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Electrike",
-            "id": "309",
-            "types": [
-                "Electric"
-            ],
-            "perfect_cp": 551,
-            "perfect_boosted": 689,
-            "perfect_cp_boosted": 689
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Manectric",
-            "id": "310",
-            "raid_level": 2,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Electric"
-            ],
-            "perfect_cp": 1337,
-            "perfect_boosted": 1672,
-            "perfect_cp_boosted": 1672
-        },
-        "availability_rules": []
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Plusle",
-            "id": "311",
-            "types": [
-                "Electric"
-            ],
-            "perfect_cp": 1016,
-            "perfect_boosted": 1270,
-            "perfect_cp_boosted": 1270,
-            "raid_level": 1
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Minun",
-            "id": "312",
-            "types": [
-                "Electric"
-            ],
-            "perfect_cp": 968,
-            "perfect_boosted": 1210,
-            "perfect_cp_boosted": 1210,
-            "raid_level": 1
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Volbeat",
-            "id": "313",
-            "types": [
-                "Bug"
-            ],
-            "perfect_cp": 1012,
-            "perfect_boosted": 1265,
-            "perfect_cp_boosted": 1265
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Illumise",
-            "id": "314",
-            "types": [
-                "Bug"
-            ],
-            "perfect_cp": 1012,
-            "perfect_boosted": 1265,
-            "perfect_cp_boosted": 1265
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Roselia",
-            "id": "315",
-            "raid_level": 2,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "perfect_cp": 1068,
-            "perfect_cp_boosted": 1335,
-            "types": [
-                "Grass",
-                "Poison"
-            ],
-            "perfect_boosted": 1335
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Gulpin",
-            "id": "316",
-            "types": [
-                "Poison"
-            ],
-            "perfect_cp": 495,
-            "perfect_boosted": 618,
-            "perfect_cp_boosted": 618
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Swalot",
-            "id": "317",
-            "types": [
-                "Poison"
-            ],
-            "perfect_cp": 1130,
-            "perfect_boosted": 1413,
-            "perfect_cp_boosted": 1413
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Carvanha",
-            "id": "318",
-            "types": [
-                "Water",
-                "Dark"
-            ],
-            "perfect_cp": 583,
-            "perfect_boosted": 729,
-            "perfect_cp_boosted": 729
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Sharpedo",
-            "id": "319",
-            "raid_level": 3,
-            "perfect_cp": 1246,
-            "perfect_cp_boosted": 1558,
-            "shiny": true,
-            "types": [
-                "Water",
-                "Dark"
-            ],
-            "perfect_boosted": 1558,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Wailmer",
-            "id": "320",
-            "raid_level": 1,
-            "perfect_cp": 838,
-            "perfect_cp_boosted": 1048,
-            "shiny": true,
-            "types": [
-                "Water"
-            ],
-            "perfect_boosted": 1048,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Wailord",
-            "id": "321",
-            "types": [
-                "Water"
-            ],
-            "perfect_cp": 1302,
-            "perfect_boosted": 1628,
-            "perfect_cp_boosted": 1628
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Numel",
-            "id": "322",
-            "types": [
-                "Fire",
-                "Ground"
-            ],
-            "perfect_cp": 604,
-            "perfect_boosted": 755,
-            "perfect_cp_boosted": 755
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Camerupt",
-            "id": "323",
-            "types": [
-                "Fire",
-                "Ground"
-            ],
-            "perfect_cp": 1253,
-            "perfect_boosted": 1566,
-            "perfect_cp_boosted": 1566
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Torkoal",
-            "id": "324",
-            "types": [
-                "Fire"
-            ],
-            "perfect_cp": 1196,
-            "perfect_boosted": 1495,
-            "perfect_cp_boosted": 1495
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Spoink",
-            "id": "325",
-            "types": [
-                "Psychic"
-            ],
-            "perfect_cp": 762,
-            "perfect_boosted": 953,
-            "perfect_cp_boosted": 953
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Grumpig",
-            "id": "326",
-            "types": [
-                "Psychic"
-            ],
-            "perfect_cp": 1354,
-            "perfect_boosted": 1692,
-            "perfect_cp_boosted": 1692
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Spinda",
-            "id": "327",
-            "types": [
-                "Normal"
-            ],
-            "perfect_cp": 697,
-            "perfect_boosted": 872,
-            "perfect_cp_boosted": 872
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Trapinch",
-            "id": "328",
-            "types": [
-                "Ground"
-            ],
-            "perfect_cp": 728,
-            "perfect_boosted": 910,
-            "perfect_cp_boosted": 910
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Vibrava",
-            "id": "329",
-            "types": [
-                "Ground",
-                "Dragon"
-            ],
-            "perfect_cp": 699,
-            "perfect_boosted": 875,
-            "perfect_cp_boosted": 875
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Flygon",
-            "id": "330",
-            "types": [
-                "Ground",
-                "Dragon"
-            ],
-            "perfect_cp": 1520,
-            "perfect_boosted": 1901,
-            "perfect_cp_boosted": 1901
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Cacnea",
-            "id": "331",
-            "types": [
-                "Grass"
-            ],
-            "perfect_cp": 709,
-            "perfect_boosted": 887,
-            "perfect_cp_boosted": 887
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Cacturne",
-            "id": "332",
-            "types": [
-                "Grass",
-                "Dark"
-            ],
-            "perfect_cp": 1313,
-            "perfect_boosted": 1641,
-            "perfect_cp_boosted": 1641
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Swablu",
-            "id": "333",
-            "raid_level": 1,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Normal",
-                "Flying"
-            ],
-            "perfect_cp": 470,
-            "perfect_boosted": 588,
-            "perfect_cp_boosted": 588
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Altaria",
-            "id": "334",
-            "types": [
-                "Dragon",
-                "Flying"
-            ],
-            "perfect_cp": 1145,
-            "perfect_boosted": 1432,
-            "perfect_cp_boosted": 1432
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Zangoose",
-            "id": "335",
-            "types": [
-                "Normal"
-            ],
-            "perfect_cp": 1381,
-            "perfect_boosted": 1727,
-            "perfect_cp_boosted": 1727
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Seviper",
-            "id": "336",
-            "types": [
-                "Poison"
-            ],
-            "perfect_cp": 1203,
-            "perfect_boosted": 1504,
-            "perfect_cp_boosted": 1504
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Lunatone",
-            "id": "337",
-            "types": [
-                "Rock",
-                "Psychic"
-            ],
-            "perfect_cp": 1330,
-            "perfect_boosted": 1662,
-            "perfect_cp_boosted": 1662,
-            "raid_level": 3
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Solrock",
-            "id": "338",
-            "types": [
-                "Rock",
-                "Psychic"
-            ],
-            "perfect_cp": 1330,
-            "perfect_boosted": 1662,
-            "perfect_cp_boosted": 1662,
-            "raid_level": 3
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Barboach",
-            "id": "339",
-            "types": [
-                "Water",
-                "Ground"
-            ],
-            "perfect_cp": 468,
-            "perfect_boosted": 585,
-            "perfect_cp_boosted": 585
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Whiscash",
-            "id": "340",
-            "types": [
-                "Water",
-                "Ground"
-            ],
-            "perfect_cp": 1186,
-            "perfect_boosted": 1482,
-            "perfect_cp_boosted": 1482
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Corphish",
-            "id": "341",
-            "types": [
-                "Water"
-            ],
-            "perfect_cp": 703,
-            "perfect_boosted": 879,
-            "perfect_cp_boosted": 879
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Crawdaunt",
-            "id": "342",
-            "types": [
-                "Water",
-                "Dark"
-            ],
-            "perfect_cp": 1413,
-            "perfect_boosted": 1767,
-            "perfect_cp_boosted": 1767,
-            "raid_level": 3
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Baltoy",
-            "id": "343",
-            "types": [
-                "Ground",
-                "Psychic"
-            ],
-            "perfect_cp": 449,
-            "perfect_boosted": 562,
-            "perfect_cp_boosted": 562
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Claydol",
-            "id": "344",
-            "raid_level": 3,
-            "perfect_cp": 1126,
-            "perfect_cp_boosted": 1408,
-            "types": [
-                "Ground",
-                "Psychic"
-            ],
-            "perfect_boosted": 1408
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Lileep",
-            "id": "345",
-            "types": [
-                "Rock",
-                "Grass"
-            ],
-            "perfect_cp": 738,
-            "perfect_boosted": 922,
-            "perfect_cp_boosted": 922
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Cradily",
-            "id": "346",
-            "types": [
-                "Rock",
-                "Grass"
-            ],
-            "perfect_cp": 1263,
-            "perfect_boosted": 1579,
-            "perfect_cp_boosted": 1579
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Anorith",
-            "id": "347",
-            "types": [
-                "Rock",
-                "Bug"
-            ],
-            "perfect_cp": 874,
-            "perfect_boosted": 1092,
-            "perfect_cp_boosted": 1092
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Armaldo",
-            "id": "348",
-            "types": [
-                "Rock",
-                "Bug"
-            ],
-            "perfect_cp": 1627,
-            "perfect_boosted": 2035,
-            "perfect_cp_boosted": 2035
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Feebas",
-            "id": "349",
-            "types": [
-                "Water"
-            ],
-            "perfect_cp": 157,
-            "perfect_boosted": 196,
-            "perfect_cp_boosted": 196
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Milotic",
-            "id": "350",
-            "types": [
-                "Water"
-            ],
-            "perfect_cp": 1717,
-            "perfect_boosted": 2147,
-            "perfect_cp_boosted": 2147
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Castform",
-            "id": "351",
-            "types": [
-                "Fire"
-            ],
-            "perfect_cp": 932,
-            "perfect_boosted": 1165,
-            "perfect_cp_boosted": 1165
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Kecleon",
-            "id": "352",
-            "types": [
-                "Normal"
-            ],
-            "perfect_cp": 1169,
-            "perfect_boosted": 1462,
-            "perfect_cp_boosted": 1462
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Shuppet",
-            "id": "353",
-            "raid_level": 1,
-            "types": [
-                "Ghost"
-            ],
-            "perfect_cp": 581,
-            "perfect_boosted": 727,
-            "perfect_cp_boosted": 727
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Banette",
-            "id": "354",
-            "types": [
-                "Ghost"
-            ],
-            "perfect_cp": 1313,
-            "perfect_boosted": 1642,
-            "perfect_cp_boosted": 1642
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Duskull",
-            "id": "355",
-            "raid_level": 1,
-            "types": [
-                "Ghost"
-            ],
-            "perfect_cp": 403,
-            "perfect_boosted": 504,
-            "perfect_cp_boosted": 504
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Dusclops",
-            "id": "356",
-            "types": [
-                "Ghost"
-            ],
-            "perfect_cp": 909,
-            "perfect_boosted": 1136,
-            "perfect_cp_boosted": 1136
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Tropius",
-            "id": "357",
-            "types": [
-                "Grass",
-                "Flying"
-            ],
-            "perfect_cp": 1109,
-            "perfect_boosted": 1386,
-            "perfect_cp_boosted": 1386
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Chimecho",
-            "id": "358",
-            "types": [
-                "Psychic"
-            ],
-            "perfect_cp": 1291,
-            "perfect_boosted": 1614,
-            "perfect_cp_boosted": 1614
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Absol",
-            "id": "359",
-            "raid_level": 4,
-            "perfect_cp": 1443,
-            "perfect_cp_boosted": 1805,
-            "shiny": true,
-            "types": [
-                "Dark"
-            ],
-            "perfect_boosted": 1805
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Wynaut",
-            "id": "360",
-            "types": [
-                "Psychic"
-            ],
-            "perfect_cp": 305,
-            "perfect_boosted": 381,
-            "perfect_cp_boosted": 381
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Snorunt",
-            "id": "361",
-            "raid_level": 1,
-            "types": [
-                "Ice"
-            ],
-            "perfect_cp": 507,
-            "perfect_boosted": 634,
-            "perfect_cp_boosted": 634,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Glalie",
-            "id": "362",
-            "types": [
-                "Ice"
-            ],
-            "perfect_cp": 1203,
-            "perfect_boosted": 1504,
-            "perfect_cp_boosted": 1504
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Spheal",
-            "id": "363",
-            "types": [
-                "Ice",
-                "Water"
-            ],
-            "perfect_cp": 550,
-            "perfect_boosted": 687,
-            "perfect_cp_boosted": 687
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Sealeo",
-            "id": "364",
-            "types": [
-                "Ice",
-                "Water"
-            ],
-            "perfect_cp": 979,
-            "perfect_boosted": 1225,
-            "perfect_cp_boosted": 1225
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Walrein",
-            "id": "365",
-            "raid_level": 4,
-            "perfect_cp": 1557,
-            "perfect_cp_boosted": 1947,
-            "types": [
-                "Ice",
-                "Water"
-            ],
-            "perfect_boosted": 1947,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Clamperl",
-            "id": "366",
-            "types": [
-                "Water"
-            ],
-            "perfect_cp": 726,
-            "perfect_boosted": 907,
-            "perfect_cp_boosted": 907
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Huntail",
-            "id": "367",
-            "types": [
-                "Water"
-            ],
-            "perfect_cp": 1337,
-            "perfect_boosted": 1671,
-            "perfect_cp_boosted": 1671
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Gorebyss",
-            "id": "368",
-            "types": [
-                "Water"
-            ],
-            "perfect_cp": 1425,
-            "perfect_boosted": 1781,
-            "perfect_cp_boosted": 1781
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Relicanth",
-            "id": "369",
-            "types": [
-                "Water",
-                "Rock"
-            ],
-            "perfect_cp": 1444,
-            "perfect_boosted": 1806,
-            "perfect_cp_boosted": 1806
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Luvdisc",
-            "id": "370",
-            "types": [
-                "Water"
-            ],
-            "perfect_cp": 484,
-            "perfect_boosted": 605,
-            "perfect_cp_boosted": 605
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Bagon",
-            "id": "371",
-            "types": [
-                "Dragon"
-            ],
-            "perfect_cp": 660,
-            "perfect_boosted": 826,
-            "perfect_cp_boosted": 826
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Shelgon",
-            "id": "372",
-            "types": [
-                "Dragon"
-            ],
-            "perfect_cp": 1160,
-            "perfect_boosted": 1451,
-            "perfect_cp_boosted": 1451
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Salamence",
-            "id": "373",
-            "types": [
-                "Dragon",
-                "Flying"
-            ],
-            "perfect_cp": 2142,
-            "perfect_boosted": 2678,
-            "perfect_cp_boosted": 2678
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Beldum",
-            "id": "374",
-            "types": [
-                "Steel",
-                "Psychic"
-            ],
-            "perfect_cp": 558,
-            "perfect_boosted": 697,
-            "perfect_cp_boosted": 697
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Metang",
-            "id": "375",
-            "types": [
-                "Steel",
-                "Psychic"
-            ],
-            "perfect_cp": 983,
-            "perfect_boosted": 1229,
-            "perfect_cp_boosted": 1229
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Metagross",
-            "id": "376",
-            "types": [
-                "Steel",
-                "Psychic"
-            ],
-            "perfect_cp": 2166,
-            "perfect_boosted": 2708,
-            "perfect_cp_boosted": 2708,
-            "raid_level": 4
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Regirock",
-            "id": "377",
-            "types": [
-                "Rock"
-            ],
-            "perfect_cp": 1784,
-            "perfect_cp_boosted": 2230,
-            "raid_level": 5,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "perfect_boosted": 2230
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Regice",
-            "id": "378",
-            "types": [
-                "Ice"
-            ],
-            "raid_level": 5,
-            "perfect_cp": 1784,
-            "perfect_cp_boosted": 2230,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "perfect_boosted": 2230
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Registeel",
-            "id": "379",
-            "types": [
-                "Steel"
-            ],
-            "perfect_cp": 1398,
-            "perfect_cp_boosted": 1748,
-            "raid_level": 5,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "perfect_boosted": 1748
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Latias",
-            "id": "380",
-            "raid_level": 5,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Dragon",
-                "Psychic"
-            ],
-            "perfect_cp": 2006,
-            "perfect_boosted": 2507,
-            "perfect_cp_boosted": 2507
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Latios",
-            "id": "381",
-            "raid_level": 5,
-            "types": [
-                "Dragon",
-                "Psychic"
-            ],
-            "perfect_cp": 2178,
-            "perfect_cp_boosted": 2723,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "perfect_boosted": 2723
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Kyogre",
-            "id": "382",
-            "raid_level": 5,
-            "types": [
-                "Water"
-            ],
-            "shiny": true,
-            "perfect_cp": 2351,
-            "perfect_cp_boosted": 2939,
-            "perfect_boosted": 2939
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Groudon",
-            "id": "383",
-            "raid_level": 5,
-            "types": [
-                "Ground"
-            ],
-            "shiny": true,
-            "perfect_cp": 2351,
-            "perfect_boosted": 2939,
-            "perfect_cp_boosted": 2939
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Rayquaza",
-            "id": "384",
-            "raid_level": 5,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Dragon",
-                "Flying"
-            ],
-            "perfect_cp": 2191,
-            "perfect_boosted": 2739,
-            "perfect_cp_boosted": 2739
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Deoxys",
-            "id": "386",
-            "perfect_cp": 1645,
-            "perfect_cp_boosted": 2056,
-            "raid_level": 5,
-            "ex": true,
-            "types": [
-                "Psychic"
-            ],
-            "perfect_boosted": 2056
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Bidoof",
-            "id": "399",
-            "raid_level": 1,
-            "perfect_cp": 412,
-            "perfect_cp_boosted": 515,
-            "types": [
-                "Normal"
-            ],
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "perfect_boosted": 515
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Kricketot",
-            "id": "401",
-            "raid_level": 1,
-            "perfect_cp": 229,
-            "perfect_cp_boosted": 286,
-            "types": [
-                "Bug"
-            ],
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "perfect_boosted": 286
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Shinx",
-            "id": "403",
-            "shiny": true,
-            "raid_level": 1,
-            "perfect_cp": 500,
-            "perfect_cp_boosted": 625,
-            "types": [
-                "Electric"
-            ],
-            "perfect_boosted": 625,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Buneary",
-            "id": "427",
-            "raid_level": 1,
-            "perfect_cp": 719,
-            "perfect_cp_boosted": 899,
-            "types": [
-                "Normal"
-            ],
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "perfect_boosted": 899
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Giratina",
-            "id": "487",
-            "raid_level": 5,
-            "perfect_cp": 2105,
-            "perfect_cp_boosted": 2631,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ],
-            "types": [
-                "Ghost",
-                "Dragon"
-            ],
-            "perfect_boosted": 2631
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Jirachi",
-            "id": 385,
-            "perfect_cp": 1865,
-            "perfect_cp_boosted": 2332,
-            "types": [
-                "Steel",
-                "Psychic"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Turtwig",
-            "id": 387,
-            "perfect_cp": 678,
-            "perfect_cp_boosted": 848,
-            "types": [
-                "Grass"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Grotle",
-            "id": 388,
-            "perfect_cp": 1080,
-            "perfect_cp_boosted": 1350,
-            "types": [
-                "Grass"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Torterra",
-            "id": 389,
-            "perfect_cp": 1677,
-            "perfect_cp_boosted": 2096,
-            "types": [
-                "Grass",
-                "Ground"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Chimchar",
-            "id": 390,
-            "perfect_cp": 547,
-            "perfect_cp_boosted": 683,
-            "types": [
-                "Fire"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Monferno",
-            "id": 391,
-            "perfect_cp": 899,
-            "perfect_cp_boosted": 1124,
-            "types": [
-                "Fire",
-                "Fighting"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Infernape",
-            "id": 392,
-            "perfect_cp": 1533,
-            "perfect_cp_boosted": 1916,
-            "types": [
-                "Fire",
-                "Fighting"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Piplup",
-            "id": 393,
-            "perfect_cp": 614,
-            "perfect_cp_boosted": 767,
-            "types": [
-                "Water"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Prinplup",
-            "id": 394,
-            "perfect_cp": 972,
-            "perfect_cp_boosted": 1215,
-            "types": [
-                "Water"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Empoleon",
-            "id": 395,
-            "perfect_cp": 1657,
-            "perfect_cp_boosted": 2072,
-            "types": [
-                "Water",
-                "Steel"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Starly",
-            "id": 396,
-            "perfect_cp": 410,
-            "perfect_cp_boosted": 513,
-            "types": [
-                "Normal",
-                "Flying"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Staravia",
-            "id": 397,
-            "perfect_cp": 742,
-            "perfect_cp_boosted": 927,
-            "types": [
-                "Normal",
-                "Flying"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Staraptor",
-            "id": 398,
-            "perfect_cp": 1614,
-            "perfect_cp_boosted": 2018,
-            "types": [
-                "Normal",
-                "Flying"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Bibarel",
-            "id": 400,
-            "perfect_cp": 1041,
-            "perfect_cp_boosted": 1302,
-            "types": [
-                "Normal",
-                "Water"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Kricketune",
-            "id": 402,
-            "perfect_cp": 944,
-            "perfect_cp_boosted": 1181,
-            "types": [
-                "Bug"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Luxio",
-            "id": 404,
-            "perfect_cp": 849,
-            "perfect_cp_boosted": 1061,
-            "types": [
-                "Electric"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Luxray",
-            "id": 405,
-            "perfect_cp": 1650,
-            "perfect_cp_boosted": 2063,
-            "types": [
-                "Electric"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Budew",
-            "id": 406,
-            "perfect_cp": 489,
-            "perfect_cp_boosted": 611,
-            "types": [
-                "Grass",
-                "Poison"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Roserade",
-            "id": 407,
-            "perfect_cp": 1697,
-            "perfect_cp_boosted": 2122,
-            "types": [
-                "Grass",
-                "Poison"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Cranidos",
-            "id": 408,
-            "perfect_cp": 1040,
-            "perfect_cp_boosted": 1300,
-            "types": [
-                "Rock",
-                "Rock"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Rampardos",
-            "id": 409,
-            "perfect_cp": 1884,
-            "perfect_cp_boosted": 2355,
-            "types": [
-                "Rock",
-                "Rock"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Shieldon",
-            "id": 410,
-            "perfect_cp": 509,
-            "perfect_cp_boosted": 636,
-            "types": [
-                "Rock",
-                "Steel"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Bastiodon",
-            "id": 411,
-            "perfect_cp": 879,
-            "perfect_cp_boosted": 1100,
-            "types": [
-                "Rock",
-                "Steel"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Burmy",
-            "id": 412,
-            "perfect_cp": 279,
-            "perfect_cp_boosted": 348,
-            "types": [
-                "Bug"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Wormadam Trash",
-            "id": 413,
-            "perfect_cp": 910,
-            "perfect_cp_boosted": 1138,
-            "types": [
-                "Bug",
-                "Steel"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Mothim",
-            "id": 414,
-            "perfect_cp": 1037,
-            "perfect_cp_boosted": 1297,
-            "types": [
-                "Bug",
-                "Flying"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Combee",
-            "id": 415,
-            "perfect_cp": 282,
-            "perfect_cp_boosted": 353,
-            "types": [
-                "Bug",
-                "Flying"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Vespiquen",
-            "id": 416,
-            "perfect_cp": 1145,
-            "perfect_cp_boosted": 1432,
-            "types": [
-                "Bug",
-                "Flying"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Pachirisu",
-            "id": 417,
-            "perfect_cp": 693,
-            "perfect_cp_boosted": 867,
-            "types": [
-                "Electric"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Buizel",
-            "id": 418,
-            "perfect_cp": 602,
-            "perfect_cp_boosted": 753,
-            "types": [
-                "Water"
-            ],
-            "raid_level": 1,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Floatzel",
-            "id": 419,
-            "perfect_cp": 1396,
-            "perfect_cp_boosted": 1745,
-            "types": [
-                "Water"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Cherubi",
-            "id": 420,
-            "perfect_cp": 542,
-            "perfect_cp_boosted": 678,
-            "types": [
-                "Grass"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Cherrim Sunny",
-            "id": 421,
-            "perfect_cp": 1170,
-            "perfect_cp_boosted": 1462,
-            "types": [
-                "Grass"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Shellos West Sea",
-            "id": 422,
-            "perfect_cp": 649,
-            "perfect_cp_boosted": 811,
-            "types": [
-                "Water"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Gastrodon West Sea",
-            "id": 423,
-            "perfect_cp": 1328,
-            "perfect_cp_boosted": 1660,
-            "types": [
-                "Water",
-                "Ground"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Ambipom",
-            "id": 424,
-            "perfect_cp": 1381,
-            "perfect_cp_boosted": 1727,
-            "types": [
-                "Normal"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Drifloon",
-            "id": 425,
-            "perfect_cp": 684,
-            "perfect_cp_boosted": 855,
-            "types": [
-                "Ghost",
-                "Flying"
-            ],
-            "raid_level": 1,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Drifblim",
-            "id": 426,
-            "perfect_cp": 1361,
-            "perfect_cp_boosted": 1701,
-            "types": [
-                "Ghost",
-                "Flying"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Lopunny",
-            "id": 428,
-            "perfect_cp": 1177,
-            "perfect_cp_boosted": 1471,
-            "types": [
-                "Normal"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Mismagius",
-            "id": 429,
-            "perfect_cp": 1494,
-            "perfect_cp_boosted": 1868,
-            "types": [
-                "Ghost"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Honchkrow",
-            "id": 430,
-            "perfect_cp": 1549,
-            "perfect_cp_boosted": 1937,
-            "types": [
-                "Dark",
-                "Flying"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Glameow",
-            "id": 431,
-            "perfect_cp": 533,
-            "perfect_cp_boosted": 667,
-            "types": [
-                "Normal"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Purugly",
-            "id": 432,
-            "perfect_cp": 1116,
-            "perfect_cp_boosted": 1395,
-            "types": [
-                "Normal"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Chingling",
-            "id": 433,
-            "perfect_cp": 574,
-            "perfect_cp_boosted": 718,
-            "types": [
-                "Psychic"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Stunky",
-            "id": 434,
-            "perfect_cp": 657,
-            "perfect_cp_boosted": 822,
-            "types": [
-                "Poison",
-                "Dark"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Skuntank",
-            "id": 435,
-            "perfect_cp": 1347,
-            "perfect_cp_boosted": 1684,
-            "types": [
-                "Poison",
-                "Dark"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Bronzor",
-            "id": 436,
-            "perfect_cp": 344,
-            "perfect_cp_boosted": 430,
-            "types": [
-                "Steel",
-                "Psychic"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Bronzong",
-            "id": 437,
-            "perfect_cp": 1279,
-            "perfect_cp_boosted": 1599,
-            "types": [
-                "Steel",
-                "Psychic"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Bonsly",
-            "id": 438,
-            "perfect_cp": 744,
-            "perfect_cp_boosted": 930,
-            "types": [
-                "Rock"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Mime Jr",
-            "id": 439,
-            "perfect_cp": 626,
-            "perfect_cp_boosted": 782,
-            "types": [
-                "Psychic",
-                "Fairy"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Happiny",
-            "id": 440,
-            "perfect_cp": 212,
-            "perfect_cp_boosted": 265,
-            "types": [
-                "Normal"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Chatot",
-            "id": 441,
-            "perfect_cp": 1023,
-            "perfect_cp_boosted": 1279,
-            "types": [
-                "Normal",
-                "Flying"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Spiritomb",
-            "id": 442,
-            "perfect_cp": 1184,
-            "perfect_cp_boosted": 1480,
-            "types": [
-                "Ghost",
-                "Dark"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Gible",
-            "id": 443,
-            "perfect_cp": 635,
-            "perfect_cp_boosted": 794,
-            "types": [
-                "Dragon",
-                "Ground"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Gabite",
-            "id": 444,
-            "perfect_cp": 1071,
-            "perfect_cp_boosted": 1339,
-            "types": [
-                "Dragon",
-                "Ground"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Garchomp",
-            "id": 445,
-            "perfect_cp": 2264,
-            "perfect_cp_boosted": 2830,
-            "types": [
-                "Dragon",
-                "Ground"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Munchlax",
-            "id": 446,
-            "perfect_cp": 1081,
-            "perfect_cp_boosted": 1351,
-            "types": [
-                "Normal"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Riolu",
-            "id": 447,
-            "perfect_cp": 567,
-            "perfect_cp_boosted": 709,
-            "types": [
-                "Fighting"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Lucario",
-            "id": 448,
-            "perfect_cp": 1544,
-            "perfect_cp_boosted": 1930,
-            "types": [
-                "Fighting",
-                "Steel"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Hippopotas",
-            "id": 449,
-            "perfect_cp": 776,
-            "perfect_cp_boosted": 970,
-            "types": [
-                "Ground"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Hippowdon",
-            "id": 450,
-            "perfect_cp": 1763,
-            "perfect_cp_boosted": 2204,
-            "types": [
-                "Ground"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Skorupi",
-            "id": 451,
-            "perfect_cp": 576,
-            "perfect_cp_boosted": 721,
-            "types": [
-                "Poison",
-                "Bug"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Drapion",
-            "id": 452,
-            "perfect_cp": 1401,
-            "perfect_cp_boosted": 1752,
-            "types": [
-                "Poison",
-                "Dark"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Croagunk",
-            "id": 453,
-            "perfect_cp": 544,
-            "perfect_cp_boosted": 680,
-            "types": [
-                "Poison",
-                "Fighting"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Toxicroak",
-            "id": 454,
-            "perfect_cp": 1421,
-            "perfect_cp_boosted": 1777,
-            "types": [
-                "Poison",
-                "Fighting"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Carnivine",
-            "id": 455,
-            "perfect_cp": 1233,
-            "perfect_cp_boosted": 1542,
-            "types": [
-                "Grass"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Finneon",
-            "id": 456,
-            "perfect_cp": 555,
-            "perfect_cp_boosted": 694,
-            "types": [
-                "Water"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Lumineon",
-            "id": 457,
-            "perfect_cp": 1036,
-            "perfect_cp_boosted": 1295,
-            "types": [
-                "Water"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Mantyke",
-            "id": 458,
-            "perfect_cp": 713,
-            "perfect_cp_boosted": 891,
-            "types": [
-                "Water",
-                "Flying"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Snover",
-            "id": 459,
-            "perfect_cp": 662,
-            "perfect_cp_boosted": 828,
-            "types": [
-                "Grass",
-                "Ice"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Abomasnow",
-            "id": 460,
-            "perfect_cp": 1349,
-            "perfect_cp_boosted": 1687,
-            "types": [
-                "Grass",
-                "Ice"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Weavile",
-            "id": 461,
-            "perfect_cp": 1717,
-            "perfect_cp_boosted": 2146,
-            "types": [
-                "Dark",
-                "Ice"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Magnezone",
-            "id": 462,
-            "perfect_cp": 1831,
-            "perfect_cp_boosted": 2289,
-            "types": [
-                "Electric",
-                "Steel"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Lickilicky",
-            "id": 463,
-            "perfect_cp": 1409,
-            "perfect_cp_boosted": 1762,
-            "types": [
-                "Normal"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Rhyperior",
-            "id": 464,
-            "perfect_cp": 2133,
-            "perfect_cp_boosted": 2667,
-            "types": [
-                "Ground",
-                "Rock"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Tangrowth",
-            "id": 465,
-            "perfect_cp": 1731,
-            "perfect_cp_boosted": 2164,
-            "types": [
-                "Grass"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Electivire",
-            "id": 466,
-            "perfect_cp": 1759,
-            "perfect_cp_boosted": 2199,
-            "types": [
-                "Electric"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Magmortar",
-            "id": 467,
-            "perfect_cp": 1790,
-            "perfect_cp_boosted": 2237,
-            "types": [
-                "Fire"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Togekiss",
-            "id": 468,
-            "perfect_cp": 1904,
-            "perfect_cp_boosted": 2380,
-            "types": [
-                "Fairy",
-                "Flying"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Yanmega",
-            "id": 469,
-            "perfect_cp": 1683,
-            "perfect_cp_boosted": 2104,
-            "types": [
-                "Bug",
-                "Flying"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Leafeon",
-            "id": 470,
-            "perfect_cp": 1682,
-            "perfect_cp_boosted": 2103,
-            "types": [
-                "Grass"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Glaceon",
-            "id": 471,
-            "perfect_cp": 1786,
-            "perfect_cp_boosted": 2233,
-            "types": [
-                "Ice"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Gliscor",
-            "id": 472,
-            "perfect_cp": 1538,
-            "perfect_cp_boosted": 1923,
-            "types": [
-                "Ground",
-                "Flying"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Mamoswine",
-            "id": 473,
-            "perfect_cp": 1902,
-            "perfect_cp_boosted": 2377,
-            "types": [
-                "Ice",
-                "Ground"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Porygon Z",
-            "id": 474,
-            "perfect_cp": 1866,
-            "perfect_cp_boosted": 2333,
-            "types": [
-                "Normal"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Gallade",
-            "id": 475,
-            "perfect_cp": 1767,
-            "perfect_cp_boosted": 2209,
-            "types": [
-                "Psychic",
-                "Fighting"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Probopass",
-            "id": 476,
-            "perfect_cp": 1188,
-            "perfect_cp_boosted": 1485,
-            "types": [
-                "Rock",
-                "Steel"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Dusknoir",
-            "id": 477,
-            "perfect_cp": 1364,
-            "perfect_cp_boosted": 1706,
-            "types": [
-                "Ghost"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Froslass",
-            "id": 478,
-            "perfect_cp": 1166,
-            "perfect_cp_boosted": 1457,
-            "types": [
-                "Ice",
-                "Ghost"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Rotom Wash",
-            "id": 479,
-            "perfect_cp": 1474,
-            "perfect_cp_boosted": 1842,
-            "types": [
-                "Electric",
-                "Water"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Uxie",
-            "id": 480,
-            "perfect_cp": 1442,
-            "perfect_cp_boosted": 1803,
-            "types": [
-                "Psychic"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Mesprit",
-            "id": 481,
-            "perfect_cp": 1747,
-            "perfect_cp_boosted": 2184,
-            "types": [
-                "Psychic"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Azelf",
-            "id": 482,
-            "perfect_cp": 1834,
-            "perfect_cp_boosted": 2293,
-            "types": [
-                "Psychic"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Dialga",
-            "id": 483,
-            "perfect_cp": 2307,
-            "perfect_cp_boosted": 2884,
-            "types": [
-                "Steel",
-                "Dragon"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Palkia",
-            "id": 484,
-            "perfect_cp": 2280,
-            "perfect_cp_boosted": 2850,
-            "types": [
-                "Water",
-                "Dragon"
-            ],
-            "raid_level":5,
-            "availability_rules":[
-                [
-                    {
-                        "type":"time",
-                        "start":"2019-01-29T21:00:00Z",
-                        "end":"2019-02-28T21:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Heatran",
-            "id": 485,
-            "perfect_cp": 2145,
-            "perfect_cp_boosted": 2681,
-            "types": [
-                "Fire",
-                "Steel"
-            ],
-            "raid_level": 5,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Regigigas",
-            "id": 486,
-            "perfect_cp": 2483,
-            "perfect_cp_boosted": 3104,
-            "types": [
-                "Normal"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Cresselia",
-            "id": 488,
-            "perfect_cp": 1633,
-            "perfect_cp_boosted": 2041,
-            "types": [
-                "Psychic"
-            ],
-            "raid_level": 5,
-            "availability_rules": [
-                [
-                    {
-                        "type": "time",
-                        "start": "2010-06-07T20:00:00Z",
-                        "end": "2010-06-07T20:00:00Z"
-                    }
-                ]
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Phione",
-            "id": 489,
-            "perfect_cp": 1203,
-            "perfect_cp_boosted": 1504,
-            "types": [
-                "Water"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Manaphy",
-            "id": 490,
-            "perfect_cp": 1865,
-            "perfect_cp_boosted": 2332,
-            "types": [
-                "Water"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Darkrai",
-            "id": 491,
-            "perfect_cp": 2136,
-            "perfect_cp_boosted": 2671,
-            "types": [
-                "Dark"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Shaymin Sky",
-            "id": 492,
-            "perfect_cp": 2052,
-            "perfect_cp_boosted": 2566,
-            "types": [
-                "Grass",
-                "Flying"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Arceus Water",
-            "id": 493,
-            "perfect_cp": 2279,
-            "perfect_cp_boosted": 2850,
-            "types": [
-                "Water"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Meltan",
-            "id": 808,
-            "perfect_cp": 617,
-            "perfect_cp_boosted": 771,
-            "types": [
-                "Steel"
-            ]
-        }
-    },
-    {
-        "type": "pokemon",
-        "data": {
-            "name": "Melmetal",
-            "id": 809,
-            "perfect_cp": 2214,
-            "perfect_cp_boosted": 2768,
-            "types": [
-                "Steel"
-            ]
-        }
-    }
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Bulbasaur",
+         "id":"001",
+         "shiny":true,
+         "raid_level":1,
+         "perfect_cp":637,
+         "perfect_cp_boosted":796,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Grass",
+            "Poison"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Ivysaur",
+         "id":"002",
+         "types":[
+            "Grass",
+            "Poison"
+         ],
+         "perfect_cp":970,
+         "perfect_cp_boosted":1213
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Venusaur",
+         "id":"003",
+         "types":[
+            "Grass",
+            "Poison"
+         ],
+         "perfect_cp":1554,
+         "perfect_cp_boosted":1943
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Charmander",
+         "id":"004",
+         "shiny":true,
+         "raid_level":1,
+         "perfect_cp":560,
+         "perfect_cp_boosted":700,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Fire"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Charmeleon",
+         "id":"005",
+         "types":[
+            "Fire"
+         ],
+         "perfect_cp":944,
+         "perfect_cp_boosted":1180
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Charizard",
+         "id":"006",
+         "types":[
+            "Fire",
+            "Flying"
+         ],
+         "perfect_cp":1651,
+         "perfect_cp_boosted":2064
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Squirtle",
+         "id":"007",
+         "shiny":true,
+         "raid_level":1,
+         "perfect_cp":540,
+         "perfect_cp_boosted":675,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Water"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Wartortle",
+         "id":"008",
+         "types":[
+            "Water"
+         ],
+         "perfect_cp":850,
+         "perfect_cp_boosted":1063
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Blastoise",
+         "id":"009",
+         "types":[
+            "Water"
+         ],
+         "perfect_cp":1409,
+         "perfect_cp_boosted":1761
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Caterpie",
+         "id":"010",
+         "types":[
+            "Bug"
+         ],
+         "perfect_cp":249,
+         "perfect_cp_boosted":312
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Metapod",
+         "id":"011",
+         "types":[
+            "Bug"
+         ],
+         "perfect_cp":257,
+         "perfect_cp_boosted":321
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Butterfree",
+         "id":"012",
+         "types":[
+            "Bug",
+            "Flying"
+         ],
+         "perfect_cp":1044,
+         "perfect_cp_boosted":1305
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Weedle",
+         "id":"013",
+         "types":[
+            "Bug",
+            "Poison"
+         ],
+         "perfect_cp":260,
+         "perfect_cp_boosted":325
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Kakuna",
+         "id":"014",
+         "types":[
+            "Bug",
+            "Poison"
+         ],
+         "perfect_cp":246,
+         "perfect_cp_boosted":308
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Beedrill",
+         "id":"015",
+         "types":[
+            "Bug",
+            "Poison"
+         ],
+         "perfect_cp":1054,
+         "perfect_cp_boosted":1318
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Pidgey",
+         "id":"016",
+         "types":[
+            "Normal",
+            "Flying"
+         ],
+         "perfect_cp":388,
+         "perfect_cp_boosted":486
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Pidgeotto",
+         "id":"017",
+         "types":[
+            "Normal",
+            "Flying"
+         ],
+         "perfect_cp":682,
+         "perfect_cp_boosted":853
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Pidgeot",
+         "id":"018",
+         "types":[
+            "Normal",
+            "Flying"
+         ],
+         "perfect_cp":1216,
+         "perfect_cp_boosted":1521
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Rattata",
+         "id":"019",
+         "types":[
+            "Dark",
+            "Normal"
+         ],
+         "perfect_cp":419,
+         "perfect_cp_boosted":524
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Raticate",
+         "id":"020",
+         "types":[
+            "Dark",
+            "Normal"
+         ],
+         "perfect_cp":974,
+         "perfect_cp_boosted":1217
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Spearow",
+         "id":"021",
+         "types":[
+            "Normal",
+            "Flying"
+         ],
+         "perfect_cp":456,
+         "perfect_cp_boosted":570
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Fearow",
+         "id":"022",
+         "types":[
+            "Normal",
+            "Flying"
+         ],
+         "perfect_cp":1141,
+         "perfect_cp_boosted":1426
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Ekans",
+         "id":"023",
+         "types":[
+            "Poison"
+         ],
+         "perfect_cp":529,
+         "perfect_cp_boosted":662
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Arbok",
+         "id":"024",
+         "types":[
+            "Poison"
+         ],
+         "perfect_cp":1097,
+         "perfect_cp_boosted":1372
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Pikachu",
+         "id":"025",
+         "types":[
+            "Electric"
+         ],
+         "perfect_cp":536,
+         "perfect_cp_boosted":670
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Raichu",
+         "id":"026",
+         "raid_level":3,
+         "types":[
+            "Electric",
+            "Psychic"
+         ],
+         "perfect_cp":1306,
+         "perfect_cp_boosted":1633,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Sandshrew",
+         "id":"027",
+         "types":[
+            "Ice",
+            "Steel"
+         ],
+         "perfect_cp":739,
+         "perfect_cp_boosted":924
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Sandslash",
+         "id":"028",
+         "types":[
+            "Ice",
+            "Steel"
+         ],
+         "perfect_cp":1390,
+         "perfect_cp_boosted":1737,
+         "raid_level":2,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Nidoran Female",
+         "id":"029",
+         "types":[
+            "Poison"
+         ],
+         "perfect_cp":466,
+         "perfect_cp_boosted":583
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Nidorina",
+         "id":"030",
+         "types":[
+            "Poison"
+         ],
+         "perfect_cp":748,
+         "perfect_cp_boosted":935
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Nidoqueen",
+         "id":"031",
+         "types":[
+            "Poison",
+            "Ground"
+         ],
+         "perfect_cp":1421,
+         "perfect_cp_boosted":1777
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Nidoran Male",
+         "id":"032",
+         "types":[
+            "Poison"
+         ],
+         "perfect_cp":491,
+         "perfect_cp_boosted":614
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Nidorino",
+         "id":"033",
+         "types":[
+            "Poison"
+         ],
+         "perfect_cp":796,
+         "perfect_cp_boosted":995
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Nidoking",
+         "id":"034",
+         "types":[
+            "Poison",
+            "Ground"
+         ],
+         "perfect_cp":1466,
+         "perfect_cp_boosted":1833
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Clefairy",
+         "id":"035",
+         "types":[
+            "Fairy"
+         ],
+         "perfect_cp":660,
+         "perfect_cp_boosted":825
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Clefable",
+         "id":"036",
+         "types":[
+            "Fairy"
+         ],
+         "perfect_cp":1392,
+         "perfect_cp_boosted":1741
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Vulpix",
+         "id":"037",
+         "types":[
+            "Ice"
+         ],
+         "perfect_cp":504,
+         "perfect_cp_boosted":631
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Ninetales",
+         "id":"038",
+         "types":[
+            "Ice",
+            "Fairy"
+         ],
+         "perfect_cp":1319,
+         "perfect_cp_boosted":1649
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Jigglypuff",
+         "id":"039",
+         "types":[
+            "Normal",
+            "Fairy"
+         ],
+         "perfect_cp":413,
+         "perfect_cp_boosted":517
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Wigglytuff",
+         "id":"040",
+         "types":[
+            "Normal",
+            "Fairy"
+         ],
+         "perfect_cp":1101,
+         "perfect_cp_boosted":1376
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Zubat",
+         "id":"041",
+         "types":[
+            "Poison",
+            "Flying"
+         ],
+         "perfect_cp":381,
+         "perfect_cp_boosted":476
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Golbat",
+         "id":"042",
+         "types":[
+            "Poison",
+            "Flying"
+         ],
+         "perfect_cp":1129,
+         "perfect_cp_boosted":1412
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Oddish",
+         "id":"043",
+         "types":[
+            "Grass",
+            "Poison"
+         ],
+         "perfect_cp":702,
+         "perfect_cp_boosted":877
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Gloom",
+         "id":"044",
+         "types":[
+            "Grass",
+            "Poison"
+         ],
+         "perfect_cp":960,
+         "perfect_cp_boosted":1200
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Vileplume",
+         "id":"045",
+         "types":[
+            "Grass",
+            "Poison"
+         ],
+         "perfect_cp":1462,
+         "perfect_cp_boosted":1828
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Paras",
+         "id":"046",
+         "types":[
+            "Bug",
+            "Grass"
+         ],
+         "perfect_cp":581,
+         "perfect_cp_boosted":727
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Parasect",
+         "id":"047",
+         "types":[
+            "Bug",
+            "Grass"
+         ],
+         "perfect_cp":1062,
+         "perfect_cp_boosted":1328
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Venonat",
+         "id":"048",
+         "types":[
+            "Bug",
+            "Poison"
+         ],
+         "perfect_cp":573,
+         "perfect_cp_boosted":717
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Venomoth",
+         "id":"049",
+         "raid_level":2,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Bug",
+            "Poison"
+         ],
+         "perfect_cp":1190,
+         "perfect_cp_boosted":1487
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Diglett",
+         "id":"050",
+         "types":[
+            "Ground",
+            "Steel"
+         ],
+         "perfect_cp":394,
+         "perfect_cp_boosted":493
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Dugtrio",
+         "id":"051",
+         "types":[
+            "Ground",
+            "Steel"
+         ],
+         "perfect_cp":1094,
+         "perfect_cp_boosted":1368
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Meowth",
+         "id":"052",
+         "types":[
+            "Dark"
+         ],
+         "perfect_cp":455,
+         "perfect_cp_boosted":569
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Persian",
+         "id":"053",
+         "types":[
+            "Dark"
+         ],
+         "perfect_cp":1012,
+         "perfect_cp_boosted":1265
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Psyduck",
+         "id":"054",
+         "types":[
+            "Water"
+         ],
+         "perfect_cp":632,
+         "perfect_cp_boosted":790
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Golduck",
+         "id":"055",
+         "types":[
+            "Water"
+         ],
+         "perfect_cp":1400,
+         "perfect_cp_boosted":1750
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Mankey",
+         "id":"056",
+         "types":[
+            "Fighting"
+         ],
+         "perfect_cp":665,
+         "perfect_cp_boosted":832
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Primeape",
+         "id":"057",
+         "raid_level":2,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Fighting"
+         ],
+         "perfect_cp":1307,
+         "perfect_cp_boosted":1634
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Growlithe",
+         "id":"058",
+         "types":[
+            "Fire"
+         ],
+         "perfect_cp":710,
+         "perfect_cp_boosted":888
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Arcanine",
+         "id":"059",
+         "types":[
+            "Fire"
+         ],
+         "perfect_cp":1731,
+         "perfect_cp_boosted":2164
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Poliwag",
+         "id":"060",
+         "types":[
+            "Water"
+         ],
+         "perfect_cp":473,
+         "perfect_cp_boosted":592
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Poliwhirl",
+         "id":"061",
+         "types":[
+            "Water"
+         ],
+         "perfect_cp":811,
+         "perfect_cp_boosted":1013
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Poliwrath",
+         "id":"062",
+         "raid_level":4,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Water",
+            "Fighting"
+         ],
+         "perfect_cp":1477,
+         "perfect_cp_boosted":1847
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Abra",
+         "id":"063",
+         "types":[
+            "Psychic"
+         ],
+         "perfect_cp":767,
+         "perfect_cp_boosted":958
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Kadabra",
+         "id":"064",
+         "types":[
+            "Psychic"
+         ],
+         "perfect_cp":1176,
+         "perfect_cp_boosted":1471
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Alakazam",
+         "id":"065",
+         "raid_level":3,
+         "types":[
+            "Psychic"
+         ],
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "perfect_cp":1747,
+         "perfect_cp_boosted":2184
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Machop",
+         "id":"066",
+         "types":[
+            "Fighting"
+         ],
+         "perfect_cp":730,
+         "perfect_cp_boosted":913
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Machoke",
+         "id":"067",
+         "types":[
+            "Fighting"
+         ],
+         "perfect_cp":1160,
+         "perfect_cp_boosted":1451
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Machamp",
+         "id":"068",
+         "raid_level":3,
+         "perfect_cp":1746,
+         "perfect_cp_boosted":2183,
+         "types":[
+            "Fighting"
+         ],
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Bellsprout",
+         "id":"069",
+         "types":[
+            "Grass",
+            "Poison"
+         ],
+         "perfect_cp":590,
+         "perfect_cp_boosted":738
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Weepinbell",
+         "id":"070",
+         "types":[
+            "Grass",
+            "Poison"
+         ],
+         "perfect_cp":921,
+         "perfect_cp_boosted":1151
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Victreebel",
+         "id":"071",
+         "types":[
+            "Grass",
+            "Poison"
+         ],
+         "perfect_cp":1389,
+         "perfect_cp_boosted":1736
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Tentacool",
+         "id":"072",
+         "types":[
+            "Water",
+            "Poison"
+         ],
+         "perfect_cp":594,
+         "perfect_cp_boosted":743
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Tentacruel",
+         "id":"073",
+         "raid_level":2,
+         "perfect_cp":1384,
+         "perfect_cp_boosted":1730,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Water",
+            "Poison"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Geodude",
+         "id":"074",
+         "types":[
+            "Rock",
+            "Electric"
+         ],
+         "perfect_cp":739,
+         "perfect_cp_boosted":923
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Graveler",
+         "id":"075",
+         "types":[
+            "Rock",
+            "Electric"
+         ],
+         "perfect_cp":1084,
+         "perfect_cp_boosted":1355
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Golem",
+         "id":"076",
+         "raid_level":4,
+         "types":[
+            "Rock",
+            "Electric"
+         ],
+         "perfect_cp":1685,
+         "perfect_cp_boosted":2106,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Ponyta",
+         "id":"077",
+         "types":[
+            "Fire"
+         ],
+         "perfect_cp":969,
+         "perfect_cp_boosted":1212
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Rapidash",
+         "id":"078",
+         "types":[
+            "Fire"
+         ],
+         "perfect_cp":1406,
+         "perfect_cp_boosted":1757
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Slowpoke",
+         "id":"079",
+         "types":[
+            "Water",
+            "Psychic"
+         ],
+         "perfect_cp":700,
+         "perfect_cp_boosted":876
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Slowbro",
+         "id":"080",
+         "raid_level":2,
+         "perfect_cp":1454,
+         "perfect_cp_boosted":1817,
+         "types":[
+            "Water",
+            "Psychic"
+         ],
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Magnemite",
+         "id":"081",
+         "types":[
+            "Electric",
+            "Steel"
+         ],
+         "raid_level":1,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "perfect_cp":778,
+         "perfect_cp_boosted":973
+      },
+      "availability_rules":[
+
+      ]
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Magneton",
+         "id":"082",
+         "raid_level":2,
+         "perfect_cp":1420,
+         "perfect_cp_boosted":1775,
+         "types":[
+            "Electric",
+            "Steel"
+         ],
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Farfetch'd",
+         "id":"083",
+         "types":[
+            "Normal",
+            "Flying"
+         ],
+         "perfect_cp":706,
+         "perfect_cp_boosted":883
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Doduo",
+         "id":"084",
+         "types":[
+            "Normal",
+            "Flying"
+         ],
+         "perfect_cp":686,
+         "perfect_cp_boosted":857
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Dodrio",
+         "id":"085",
+         "types":[
+            "Normal",
+            "Flying"
+         ],
+         "perfect_cp":1349,
+         "perfect_cp_boosted":1687
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Seel",
+         "id":"086",
+         "types":[
+            "Water"
+         ],
+         "perfect_cp":555,
+         "perfect_cp_boosted":694
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Dewgong",
+         "id":"087",
+         "types":[
+            "Water",
+            "Ice"
+         ],
+         "perfect_cp":1134,
+         "perfect_cp_boosted":1418,
+         "raid_level":2,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Grimer",
+         "id":"088",
+         "types":[
+            "Poison",
+            "Dark"
+         ],
+         "perfect_cp":785,
+         "perfect_cp_boosted":981
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Muk",
+         "id":"089",
+         "raid_level":2,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Poison",
+            "Dark"
+         ],
+         "perfect_cp":1575,
+         "perfect_cp_boosted":1969
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Shellder",
+         "id":"090",
+         "raid_level":1,
+         "perfect_cp":617,
+         "perfect_cp_boosted":771,
+         "shiny":true,
+         "types":[
+            "Water"
+         ],
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Cloyster",
+         "id":"091",
+         "types":[
+            "Water",
+            "Ice"
+         ],
+         "perfect_cp":1455,
+         "perfect_cp_boosted":1819
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Gastly",
+         "id":"092",
+         "types":[
+            "Ghost",
+            "Poison"
+         ],
+         "perfect_cp":702,
+         "perfect_cp_boosted":878
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Haunter",
+         "id":"093",
+         "types":[
+            "Ghost",
+            "Poison"
+         ],
+         "perfect_cp":1121,
+         "perfect_cp_boosted":1402
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Gengar",
+         "id":"094",
+         "raid_level":3,
+         "types":[
+            "Ghost",
+            "Poison"
+         ],
+         "perfect_cp":1644,
+         "perfect_cp_boosted":2055,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Onix",
+         "id":"095",
+         "raid_level":3,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Rock",
+            "Ground"
+         ],
+         "perfect_cp":629,
+         "perfect_cp_boosted":787
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Drowzee",
+         "id":"096",
+         "raid_level":1,
+         "types":[
+            "Psychic"
+         ],
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "perfect_cp":594,
+         "perfect_cp_boosted":743
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Hypno",
+         "id":"097",
+         "types":[
+            "Psychic"
+         ],
+         "perfect_cp":1194,
+         "perfect_cp_boosted":1493
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Krabby",
+         "id":"098",
+         "types":[
+            "Water"
+         ],
+         "perfect_cp":892,
+         "perfect_cp_boosted":1115
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Kingler",
+         "id":"099",
+         "types":[
+            "Water"
+         ],
+         "perfect_cp":1616,
+         "perfect_cp_boosted":2020
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Voltorb",
+         "id":"100",
+         "types":[
+            "Electric"
+         ],
+         "perfect_cp":577,
+         "perfect_cp_boosted":721
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Electrode",
+         "id":"101",
+         "types":[
+            "Electric"
+         ],
+         "perfect_cp":1199,
+         "perfect_cp_boosted":1499
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Exeggcute",
+         "id":"102",
+         "types":[
+            "Grass",
+            "Psychic"
+         ],
+         "perfect_cp":671,
+         "perfect_cp_boosted":839
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Exeggutor",
+         "id":"103",
+         "raid_level":2,
+         "perfect_cp":1722,
+         "perfect_cp_boosted":2153,
+         "types":[
+            "Grass",
+            "Dragon"
+         ],
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Cubone",
+         "id":"104",
+         "types":[
+            "Ground"
+         ],
+         "perfect_cp":582,
+         "perfect_cp_boosted":728
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Marowak",
+         "id":"105",
+         "raid_level":4,
+         "perfect_cp":1048,
+         "perfect_cp_boosted":1311,
+         "types":[
+            "Fire",
+            "Ghost"
+         ],
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Hitmonlee",
+         "id":"106",
+         "raid_level":3,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Fighting"
+         ],
+         "perfect_cp":1472,
+         "perfect_cp_boosted":1840
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Hitmonchan",
+         "id":"107",
+         "raid_level":3,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Fighting"
+         ],
+         "perfect_cp":1332,
+         "perfect_cp_boosted":1665
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Lickitung",
+         "id":"108",
+         "raid_level":2,
+         "perfect_cp":806,
+         "perfect_cp_boosted":1008,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Normal"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Koffing",
+         "id":"109",
+         "types":[
+            "Poison"
+         ],
+         "perfect_cp":694,
+         "perfect_cp_boosted":867
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Weezing",
+         "id":"110",
+         "raid_level":2,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Poison"
+         ],
+         "perfect_cp":1310,
+         "perfect_cp_boosted":1637
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Rhyhorn",
+         "id":"111",
+         "types":[
+            "Ground",
+            "Rock"
+         ],
+         "perfect_cp":943,
+         "perfect_cp_boosted":1179
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Rhydon",
+         "id":"112",
+         "raid_level":4,
+         "types":[
+            "Ground",
+            "Rock"
+         ],
+         "perfect_cp":1816,
+         "perfect_cp_boosted":2270,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Chansey",
+         "id":"113",
+         "types":[
+            "Normal"
+         ],
+         "perfect_cp":717,
+         "perfect_cp_boosted":896
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Tangela",
+         "id":"114",
+         "raid_level":3,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "perfect_cp":1278,
+         "perfect_cp_boosted":1598,
+         "types":[
+            "Grass"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Kangaskhan",
+         "id":"115",
+         "types":[
+            "Normal"
+         ],
+         "perfect_cp":1477,
+         "perfect_cp_boosted":1847
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Horsea",
+         "id":"116",
+         "types":[
+            "Water"
+         ],
+         "perfect_cp":603,
+         "perfect_cp_boosted":754
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Seadra",
+         "id":"117",
+         "types":[
+            "Water"
+         ],
+         "perfect_cp":1196,
+         "perfect_cp_boosted":1495
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Goldeen",
+         "id":"118",
+         "types":[
+            "Water"
+         ],
+         "perfect_cp":658,
+         "perfect_cp_boosted":823
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Seaking",
+         "id":"119",
+         "types":[
+            "Water"
+         ],
+         "perfect_cp":1235,
+         "perfect_cp_boosted":1544
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Staryu",
+         "id":"120",
+         "types":[
+            "Water"
+         ],
+         "perfect_cp":661,
+         "perfect_cp_boosted":826
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Starmie",
+         "id":"121",
+         "raid_level":3,
+         "perfect_cp":1476,
+         "perfect_cp_boosted":1846,
+         "types":[
+            "Water",
+            "Psychic"
+         ],
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Mr. Mime",
+         "id":"122",
+         "types":[
+            "Psychic",
+            "Fairy"
+         ],
+         "perfect_cp":1273,
+         "perfect_cp_boosted":1591
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Scyther",
+         "id":"123",
+         "raid_level":3,
+         "types":[
+            "Bug",
+            "Flying"
+         ],
+         "perfect_cp":1546,
+         "perfect_cp_boosted":1933,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Jynx",
+         "id":"124",
+         "raid_level":3,
+         "types":[
+            "Ice",
+            "Psychic"
+         ],
+         "perfect_cp":1460,
+         "perfect_cp_boosted":1825,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Electabuzz",
+         "id":"125",
+         "raid_level":2,
+         "perfect_cp":1333,
+         "perfect_cp_boosted":1667,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Electric"
+         ]
+      },
+      "availability_rules":[
+
+      ]
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Magmar",
+         "id":"126",
+         "raid_level":2,
+         "types":[
+            "Fire"
+         ],
+         "perfect_cp":1367,
+         "perfect_cp_boosted":1710,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Pinsir",
+         "id":"127",
+         "raid_level":3,
+         "types":[
+            "Bug"
+         ],
+         "perfect_cp":1690,
+         "perfect_cp_boosted":2113,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Tauros",
+         "id":"128",
+         "types":[
+            "Normal"
+         ],
+         "perfect_cp":1497,
+         "perfect_cp_boosted":1872
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Magikarp",
+         "id":"129",
+         "raid_level":1,
+         "perfect_cp":157,
+         "perfect_cp_boosted":196,
+         "shiny":true,
+         "types":[
+            "Water"
+         ],
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Gyarados",
+         "id":"130",
+         "types":[
+            "Water",
+            "Flying"
+         ],
+         "perfect_cp":1937,
+         "perfect_cp_boosted":2422
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Lapras",
+         "id":"131",
+         "raid_level":4,
+         "types":[
+            "Water",
+            "Ice"
+         ],
+         "perfect_cp":1509,
+         "perfect_cp_boosted":1886,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Ditto",
+         "id":"132",
+         "types":[
+            "Normal"
+         ],
+         "perfect_cp":475,
+         "perfect_cp_boosted":594
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Eevee",
+         "id":"133",
+         "types":[
+            "Normal"
+         ],
+         "perfect_cp":612,
+         "perfect_cp_boosted":765
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Vaporeon",
+         "id":"134",
+         "raid_level":3,
+         "perfect_cp":1779,
+         "perfect_cp_boosted":2225,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Water"
+         ]
+      },
+      "availability_rules":[
+
+      ]
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Jolteon",
+         "id":"135",
+         "raid_level":3,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Electric"
+         ],
+         "perfect_cp":1650,
+         "perfect_cp_boosted":2063
+      },
+      "availability_rules":[
+
+      ]
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Flareon",
+         "id":"136",
+         "raid_level":3,
+         "types":[
+            "Fire"
+         ],
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "perfect_cp":1730,
+         "perfect_cp_boosted":2163
+      },
+      "availability_rules":[
+
+      ]
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Porygon",
+         "id":"137",
+         "raid_level":3,
+         "types":[
+            "Normal"
+         ],
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "perfect_cp":982,
+         "perfect_cp_boosted":1228
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Omanyte",
+         "id":"138",
+         "raid_level":1,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "perfect_cp":882,
+         "perfect_cp_boosted":1103,
+         "shiny":true,
+         "types":[
+            "Rock",
+            "Water"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Omastar",
+         "id":"139",
+         "raid_level":3,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Rock",
+            "Water"
+         ],
+         "perfect_cp":1592,
+         "perfect_cp_boosted":1990
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Kabuto",
+         "id":"140",
+         "perfect_cp":783,
+         "perfect_cp_boosted":979,
+         "shiny":true,
+         "raid_level":1,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Rock",
+            "Water"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Kabutops",
+         "id":"141",
+         "raid_level":3,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Rock",
+            "Water"
+         ],
+         "perfect_cp":1550,
+         "perfect_cp_boosted":1938
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Aerodactyl",
+         "id":"142",
+         "raid_level":3,
+         "shiny":true,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Rock",
+            "Flying"
+         ],
+         "perfect_cp":1590,
+         "perfect_cp_boosted":1988
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Snorlax",
+         "id":"143",
+         "raid_level":4,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Normal"
+         ],
+         "perfect_cp":1843,
+         "perfect_cp_boosted":2304
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Articuno",
+         "id":"144",
+         "raid_level":5,
+         "shiny":true,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Ice",
+            "Flying"
+         ],
+         "perfect_cp":1743,
+         "perfect_cp_boosted":2179
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Zapdos",
+         "id":"145",
+         "raid_level":5,
+         "shiny":true,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Electric",
+            "Flying"
+         ],
+         "perfect_cp":2015,
+         "perfect_cp_boosted":2519
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Moltres",
+         "id":"146",
+         "raid_level":5,
+         "shiny":true,
+         "perfect_cp":1980,
+         "perfect_cp_boosted":2475,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Fire",
+            "Flying"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Dratini",
+         "id":"147",
+         "types":[
+            "Dragon"
+         ],
+         "shiny":true,
+         "raid_level":1,
+         "perfect_cp":574,
+         "perfect_cp_boosted":717,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Dragonair",
+         "id":"148",
+         "types":[
+            "Dragon"
+         ],
+         "perfect_cp":1017,
+         "perfect_cp_boosted":1271
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Dragonite",
+         "id":"149",
+         "types":[
+            "Dragon",
+            "Flying"
+         ],
+         "perfect_cp":2167,
+         "perfect_cp_boosted":2709
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Mewtwo",
+         "id":"150",
+         "raid_level":5,
+         "shiny":false,
+         "perfect_cp":2387,
+         "perfect_cp_boosted":2984,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Psychic"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Mew",
+         "id":"151",
+         "types":[
+            "Psychic"
+         ],
+         "perfect_cp":1865,
+         "perfect_cp_boosted":2332
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Chikorita",
+         "id":"152",
+         "types":[
+            "Grass"
+         ],
+         "perfect_cp":534,
+         "perfect_cp_boosted":668
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Bayleef",
+         "id":"153",
+         "types":[
+            "Grass"
+         ],
+         "perfect_cp":831,
+         "perfect_cp_boosted":1039
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Meganium",
+         "id":"154",
+         "types":[
+            "Grass"
+         ],
+         "perfect_cp":1377,
+         "perfect_cp_boosted":1721
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Cyndaquil",
+         "id":"155",
+         "types":[
+            "Fire"
+         ],
+         "perfect_cp":560,
+         "perfect_cp_boosted":700
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Quilava",
+         "id":"156",
+         "types":[
+            "Fire"
+         ],
+         "perfect_cp":944,
+         "perfect_cp_boosted":1180
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Typhlosion",
+         "id":"157",
+         "types":[
+            "Fire"
+         ],
+         "perfect_cp":1651,
+         "perfect_cp_boosted":2064
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Totodile",
+         "id":"158",
+         "types":[
+            "Water"
+         ],
+         "perfect_cp":646,
+         "perfect_cp_boosted":808
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Croconaw",
+         "id":"159",
+         "raid_level":2,
+         "perfect_cp":984,
+         "perfect_cp_boosted":1230,
+         "types":[
+            "Water"
+         ],
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Feraligatr",
+         "id":"160",
+         "types":[
+            "Water"
+         ],
+         "perfect_cp":1632,
+         "perfect_cp_boosted":2040
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Sentret",
+         "id":"161",
+         "types":[
+            "Normal"
+         ],
+         "perfect_cp":353,
+         "perfect_cp_boosted":441
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Furret",
+         "id":"162",
+         "types":[
+            "Normal"
+         ],
+         "perfect_cp":1004,
+         "perfect_cp_boosted":1255
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Hoothoot",
+         "id":"163",
+         "types":[
+            "Normal",
+            "Flying"
+         ],
+         "perfect_cp":387,
+         "perfect_cp_boosted":484
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Noctowl",
+         "id":"164",
+         "types":[
+            "Normal",
+            "Flying"
+         ],
+         "perfect_cp":1156,
+         "perfect_cp_boosted":1446
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Ledyba",
+         "id":"165",
+         "types":[
+            "Bug",
+            "Flying"
+         ],
+         "perfect_cp":416,
+         "perfect_cp_boosted":520
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Ledian",
+         "id":"166",
+         "types":[
+            "Bug",
+            "Flying"
+         ],
+         "perfect_cp":769,
+         "perfect_cp_boosted":961
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Spinarak",
+         "id":"167",
+         "types":[
+            "Bug",
+            "Poison"
+         ],
+         "perfect_cp":466,
+         "perfect_cp_boosted":583
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Ariados",
+         "id":"168",
+         "types":[
+            "Bug",
+            "Poison"
+         ],
+         "perfect_cp":1012,
+         "perfect_cp_boosted":1265
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Crobat",
+         "id":"169",
+         "types":[
+            "Poison",
+            "Flying"
+         ],
+         "perfect_cp":1512,
+         "perfect_cp_boosted":1890
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Chinchou",
+         "id":"170",
+         "types":[
+            "Water",
+            "Electric"
+         ],
+         "perfect_cp":639,
+         "perfect_cp_boosted":799
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Lanturn",
+         "id":"171",
+         "types":[
+            "Water",
+            "Electric"
+         ],
+         "perfect_cp":1191,
+         "perfect_cp_boosted":1489,
+         "raid_level":2,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      },
+      "availability_rules":[
+
+      ]
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Pichu",
+         "id":"172",
+         "types":[
+            "Electric"
+         ],
+         "perfect_cp":270,
+         "perfect_cp_boosted":338
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Cleffa",
+         "id":"173",
+         "types":[
+            "Fairy"
+         ],
+         "perfect_cp":383,
+         "perfect_cp_boosted":479
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Igglybuff",
+         "id":"174",
+         "types":[
+            "Normal",
+            "Fairy"
+         ],
+         "perfect_cp":306,
+         "perfect_cp_boosted":382
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Togepi",
+         "id":"175",
+         "types":[
+            "Fairy"
+         ],
+         "perfect_cp":375,
+         "perfect_cp_boosted":470
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Togetic",
+         "id":"176",
+         "raid_level":4,
+         "types":[
+            "Fairy",
+            "Flying"
+         ],
+         "perfect_cp":976,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "perfect_cp_boosted":1220
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Natu",
+         "id":"177",
+         "types":[
+            "Psychic",
+            "Flying"
+         ],
+         "perfect_cp":630,
+         "perfect_cp_boosted":787
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Xatu",
+         "id":"178",
+         "types":[
+            "Psychic",
+            "Flying"
+         ],
+         "perfect_cp":1250,
+         "perfect_cp_boosted":1563
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Mareep",
+         "id":"179",
+         "types":[
+            "Electric"
+         ],
+         "perfect_cp":566,
+         "perfect_cp_boosted":708,
+         "raid_level":1,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      },
+      "availability_rules":[
+
+      ]
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Flaaffy",
+         "id":"180",
+         "types":[
+            "Electric"
+         ],
+         "perfect_cp":869,
+         "perfect_cp_boosted":1086
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Ampharos",
+         "id":"181",
+         "types":[
+            "Electric"
+         ],
+         "perfect_cp":1630,
+         "perfect_cp_boosted":2037
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Bellossom",
+         "id":"182",
+         "types":[
+            "Grass"
+         ],
+         "perfect_cp":1303,
+         "perfect_cp_boosted":1629
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Marill",
+         "id":"183",
+         "types":[
+            "Water",
+            "Fairy"
+         ],
+         "perfect_cp":263,
+         "perfect_cp_boosted":329
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Azumarill",
+         "id":"184",
+         "types":[
+            "Water",
+            "Fairy"
+         ],
+         "perfect_cp":907,
+         "perfect_cp_boosted":1134
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Sudowoodo",
+         "id":"185",
+         "raid_level":2,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Rock"
+         ],
+         "perfect_cp":1227,
+         "perfect_cp_boosted":1534
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Politoed",
+         "id":"186",
+         "types":[
+            "Water"
+         ],
+         "perfect_cp":1399,
+         "perfect_cp_boosted":1749
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Hoppip",
+         "id":"187",
+         "types":[
+            "Grass",
+            "Flying"
+         ],
+         "perfect_cp":342,
+         "perfect_cp_boosted":428
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Skiploom",
+         "id":"188",
+         "types":[
+            "Grass",
+            "Flying"
+         ],
+         "perfect_cp":557,
+         "perfect_cp_boosted":697
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Jumpluff",
+         "id":"189",
+         "types":[
+            "Grass",
+            "Flying"
+         ],
+         "perfect_cp":935,
+         "perfect_cp_boosted":1168
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Aipom",
+         "id":"190",
+         "types":[
+            "Normal"
+         ],
+         "perfect_cp":770,
+         "perfect_cp_boosted":963
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Sunkern",
+         "id":"191",
+         "types":[
+            "Grass"
+         ],
+         "perfect_cp":226,
+         "perfect_cp_boosted":282
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Sunflora",
+         "id":"192",
+         "types":[
+            "Grass"
+         ],
+         "perfect_cp":1223,
+         "perfect_cp_boosted":1529
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Yanma",
+         "id":"193",
+         "types":[
+            "Bug",
+            "Flying"
+         ],
+         "perfect_cp":840,
+         "perfect_cp_boosted":1050
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Wooper",
+         "id":"194",
+         "types":[
+            "Water",
+            "Ground"
+         ],
+         "perfect_cp":366,
+         "perfect_cp_boosted":458
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Quagsire",
+         "id":"195",
+         "types":[
+            "Water",
+            "Ground"
+         ],
+         "perfect_cp":1138,
+         "perfect_cp_boosted":1423
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Espeon",
+         "id":"196",
+         "types":[
+            "Psychic"
+         ],
+         "perfect_cp":1811,
+         "perfect_cp_boosted":2264,
+         "raid_level":3,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      },
+      "availability_rules":[
+
+      ]
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Umbreon",
+         "id":"197",
+         "types":[
+            "Dark"
+         ],
+         "perfect_cp":1221,
+         "perfect_cp_boosted":1526,
+         "raid_level":3,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      },
+      "availability_rules":[
+
+      ]
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Murkrow",
+         "id":"198",
+         "types":[
+            "Dark",
+            "Flying"
+         ],
+         "perfect_cp":892,
+         "perfect_cp_boosted":1116
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Slowking",
+         "id":"199",
+         "types":[
+            "Water",
+            "Psychic"
+         ],
+         "perfect_cp":1454,
+         "perfect_cp_boosted":1817
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Misdreavus",
+         "id":"200",
+         "raid_level":2,
+         "types":[
+            "Ghost"
+         ],
+         "perfect_cp":1100,
+         "perfect_cp_boosted":1376,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Unown",
+         "id":"201",
+         "types":[
+            "Psychic"
+         ],
+         "perfect_cp":677,
+         "perfect_cp_boosted":846
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Wobbuffet",
+         "id":"202",
+         "types":[
+            "Psychic"
+         ],
+         "perfect_cp":586,
+         "perfect_cp_boosted":733
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Girafarig",
+         "id":"203",
+         "types":[
+            "Normal",
+            "Psychic"
+         ],
+         "perfect_cp":1169,
+         "perfect_cp_boosted":1462
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Pineco",
+         "id":"204",
+         "types":[
+            "Bug"
+         ],
+         "perfect_cp":633,
+         "perfect_cp_boosted":791
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Forretress",
+         "id":"205",
+         "types":[
+            "Bug",
+            "Steel"
+         ],
+         "perfect_cp":1304,
+         "perfect_cp_boosted":1630
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Dunsparce",
+         "id":"206",
+         "types":[
+            "Normal"
+         ],
+         "perfect_cp":965,
+         "perfect_cp_boosted":1206
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Gligar",
+         "id":"207",
+         "types":[
+            "Ground",
+            "Flying"
+         ],
+         "perfect_cp":1061,
+         "perfect_cp_boosted":1326
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Steelix",
+         "id":"208",
+         "types":[
+            "Steel",
+            "Ground"
+         ],
+         "perfect_cp":1379,
+         "perfect_cp_boosted":1724
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Snubbull",
+         "id":"209",
+         "types":[
+            "Fairy"
+         ],
+         "perfect_cp":707,
+         "perfect_cp_boosted":884
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Granbull",
+         "id":"210",
+         "raid_level":3,
+         "types":[
+            "Fairy"
+         ],
+         "perfect_cp":1458,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "perfect_cp_boosted":1823
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Qwilfish",
+         "id":"211",
+         "types":[
+            "Water",
+            "Poison"
+         ],
+         "perfect_cp":1172,
+         "perfect_cp_boosted":1465
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Scizor",
+         "id":"212",
+         "types":[
+            "Bug",
+            "Steel"
+         ],
+         "perfect_cp":1714,
+         "perfect_cp_boosted":2143
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Shuckle",
+         "id":"213",
+         "types":[
+            "Bug",
+            "Rock"
+         ],
+         "perfect_cp":231,
+         "perfect_cp_boosted":289
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Heracross",
+         "id":"214",
+         "types":[
+            "Bug",
+            "Fighting"
+         ],
+         "perfect_cp":1772,
+         "perfect_cp_boosted":2215
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Sneasel",
+         "id":"215",
+         "raid_level":2,
+         "types":[
+            "Dark",
+            "Ice"
+         ],
+         "perfect_cp":1172,
+         "perfect_cp_boosted":1465,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Teddiursa",
+         "id":"216",
+         "types":[
+            "Normal"
+         ],
+         "perfect_cp":759,
+         "perfect_cp_boosted":949
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Ursaring",
+         "id":"217",
+         "types":[
+            "Normal"
+         ],
+         "perfect_cp":1682,
+         "perfect_cp_boosted":2103
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Slugma",
+         "id":"218",
+         "types":[
+            "Fire"
+         ],
+         "perfect_cp":511,
+         "perfect_cp_boosted":639
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Magcargo",
+         "id":"219",
+         "types":[
+            "Fire",
+            "Rock"
+         ],
+         "perfect_cp":972,
+         "perfect_cp_boosted":1215
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Swinub",
+         "id":"220",
+         "types":[
+            "Ice",
+            "Ground"
+         ],
+         "perfect_cp":423,
+         "perfect_cp_boosted":529
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Piloswine",
+         "id":"221",
+         "raid_level":3,
+         "types":[
+            "Ice",
+            "Ground"
+         ],
+         "perfect_cp":1340,
+         "perfect_cp_boosted":1675,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Corsola",
+         "id":"222",
+         "types":[
+            "Water",
+            "Rock"
+         ],
+         "perfect_cp":787,
+         "perfect_cp_boosted":984
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Remoraid",
+         "id":"223",
+         "types":[
+            "Water"
+         ],
+         "perfect_cp":521,
+         "perfect_cp_boosted":651
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Octillery",
+         "id":"224",
+         "types":[
+            "Water"
+         ],
+         "perfect_cp":1322,
+         "perfect_cp_boosted":1653
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Delibird",
+         "id":"225",
+         "types":[
+            "Ice",
+            "Flying"
+         ],
+         "perfect_cp":625,
+         "perfect_cp_boosted":781
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Mantine",
+         "id":"226",
+         "types":[
+            "Water",
+            "Flying"
+         ],
+         "perfect_cp":1204,
+         "perfect_cp_boosted":1506
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Skarmory",
+         "id":"227",
+         "types":[
+            "Steel",
+            "Flying"
+         ],
+         "perfect_cp":1204,
+         "perfect_cp_boosted":1506
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Houndour",
+         "id":"228",
+         "types":[
+            "Dark",
+            "Fire"
+         ],
+         "perfect_cp":705,
+         "perfect_cp_boosted":881
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Houndoom",
+         "id":"229",
+         "raid_level":4,
+         "types":[
+            "Dark",
+            "Fire"
+         ],
+         "perfect_cp":1505,
+         "perfect_cp_boosted":1882,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Kingdra",
+         "id":"230",
+         "types":[
+            "Water",
+            "Dragon"
+         ],
+         "perfect_cp":1509,
+         "perfect_cp_boosted":1887
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Phanpy",
+         "id":"231",
+         "types":[
+            "Ground"
+         ],
+         "perfect_cp":689,
+         "perfect_cp_boosted":862
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Donphan",
+         "id":"232",
+         "raid_level":3,
+         "types":[
+            "Ground"
+         ],
+         "perfect_cp":1722,
+         "perfect_cp_boosted":2152,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Porygon2",
+         "id":"233",
+         "types":[
+            "Normal"
+         ],
+         "perfect_cp":1549,
+         "perfect_cp_boosted":1936
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Stantler",
+         "id":"234",
+         "types":[
+            "Normal"
+         ],
+         "perfect_cp":1236,
+         "perfect_cp_boosted":1546
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Smeargle",
+         "id":"235",
+         "types":[
+            "Normal"
+         ],
+         "perfect_cp":246,
+         "perfect_cp_boosted":308
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Tyrogue",
+         "id":"236",
+         "types":[
+            "Fighting"
+         ],
+         "perfect_cp":281,
+         "perfect_cp_boosted":351
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Hitmontop",
+         "id":"237",
+         "types":[
+            "Fighting"
+         ],
+         "perfect_cp":1232,
+         "perfect_cp_boosted":1540
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Smoochum",
+         "id":"238",
+         "types":[
+            "Ice",
+            "Psychic"
+         ],
+         "perfect_cp":738,
+         "perfect_cp_boosted":922
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Elekid",
+         "id":"239",
+         "types":[
+            "Electric"
+         ],
+         "perfect_cp":689,
+         "perfect_cp_boosted":861
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Magby",
+         "id":"240",
+         "types":[
+            "Fire"
+         ],
+         "perfect_cp":756,
+         "perfect_cp_boosted":945
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Miltank",
+         "id":"241",
+         "types":[
+            "Normal"
+         ],
+         "perfect_cp":1345,
+         "perfect_cp_boosted":1682
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Blissey",
+         "id":"242",
+         "types":[
+            "Normal"
+         ],
+         "perfect_cp":1575,
+         "perfect_cp_boosted":1969
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Raikou",
+         "id":"243",
+         "raid_level":5,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Electric"
+         ],
+         "perfect_cp":1972,
+         "perfect_cp_boosted":2466
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Entei",
+         "id":"244",
+         "raid_level":5,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Fire"
+         ],
+         "perfect_cp":1984,
+         "perfect_cp_boosted":2480
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Suicune",
+         "id":"245",
+         "raid_level":5,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Water"
+         ],
+         "perfect_cp":1704,
+         "perfect_cp_boosted":2130
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Larvitar",
+         "id":"246",
+         "types":[
+            "Rock",
+            "Ground"
+         ],
+         "perfect_cp":594,
+         "perfect_cp_boosted":743
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Pupitar",
+         "id":"247",
+         "types":[
+            "Rock",
+            "Ground"
+         ],
+         "perfect_cp":1009,
+         "perfect_cp_boosted":1261
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Tyranitar",
+         "id":"248",
+         "raid_level":4,
+         "perfect_cp":2191,
+         "perfect_cp_boosted":2739,
+         "types":[
+            "Rock",
+            "Dark"
+         ],
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Lugia",
+         "id":"249",
+         "raid_level":5,
+         "types":[
+            "Psychic",
+            "Flying"
+         ],
+         "perfect_cp":2115,
+         "perfect_cp_boosted":2645,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Ho-Oh",
+         "id":"250",
+         "raid_level":5,
+         "types":[
+            "Fire",
+            "Flying"
+         ],
+         "perfect_cp":2207,
+         "perfect_cp_boosted":2759,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Celebi",
+         "id":"251",
+         "types":[
+            "Psychic",
+            "Grass"
+         ],
+         "perfect_cp":1865,
+         "perfect_cp_boosted":2332
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Treecko",
+         "id":"252",
+         "types":[
+            "Grass"
+         ],
+         "perfect_cp":601,
+         "perfect_cp_boosted":752
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Grovyle",
+         "id":"253",
+         "types":[
+            "Grass"
+         ],
+         "perfect_cp":956,
+         "perfect_cp_boosted":1195,
+         "raid_level":2
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Sceptile",
+         "id":"254",
+         "types":[
+            "Grass"
+         ],
+         "perfect_cp":1575,
+         "perfect_cp_boosted":1969
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Torchic",
+         "id":"255",
+         "types":[
+            "Fire"
+         ],
+         "perfect_cp":624,
+         "perfect_cp_boosted":781
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Combusken",
+         "id":"256",
+         "raid_level":2,
+         "types":[
+            "Fire",
+            "Fighting"
+         ],
+         "perfect_cp":944,
+         "perfect_cp_boosted":1180
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Blaziken",
+         "id":"257",
+         "types":[
+            "Fire",
+            "Fighting"
+         ],
+         "perfect_cp":1627,
+         "perfect_cp_boosted":2034
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Mudkip",
+         "id":"258",
+         "types":[
+            "Water"
+         ],
+         "perfect_cp":644,
+         "perfect_cp_boosted":805
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Marshtomp",
+         "id":"259",
+         "raid_level":2,
+         "perfect_cp":1015,
+         "perfect_cp_boosted":1269,
+         "shiny":true,
+         "types":[
+            "Water",
+            "Ground"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Swampert",
+         "id":"260",
+         "types":[
+            "Water",
+            "Ground"
+         ],
+         "perfect_cp":1699,
+         "perfect_cp_boosted":2124
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Poochyena",
+         "id":"261",
+         "types":[
+            "Dark"
+         ],
+         "perfect_cp":387,
+         "perfect_cp_boosted":484
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Mightyena",
+         "id":"262",
+         "types":[
+            "Dark"
+         ],
+         "perfect_cp":1100,
+         "perfect_cp_boosted":1375
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Zigzagoon",
+         "id":"263",
+         "types":[
+            "Normal"
+         ],
+         "perfect_cp":290,
+         "perfect_cp_boosted":363
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Linoone",
+         "id":"264",
+         "types":[
+            "Normal"
+         ],
+         "perfect_cp":949,
+         "perfect_cp_boosted":1187
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Wurmple",
+         "id":"265",
+         "types":[
+            "Bug"
+         ],
+         "perfect_cp":330,
+         "perfect_cp_boosted":413
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Silcoon",
+         "id":"266",
+         "types":[
+            "Bug"
+         ],
+         "perfect_cp":316,
+         "perfect_cp_boosted":395
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Beautifly",
+         "id":"267",
+         "types":[
+            "Bug",
+            "Flying"
+         ],
+         "perfect_cp":1009,
+         "perfect_cp_boosted":1261
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Cascoon",
+         "id":"268",
+         "types":[
+            "Bug"
+         ],
+         "perfect_cp":316,
+         "perfect_cp_boosted":395
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Dustox",
+         "id":"269",
+         "types":[
+            "Bug",
+            "Poison"
+         ],
+         "perfect_cp":699,
+         "perfect_cp_boosted":874
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Lotad",
+         "id":"270",
+         "types":[
+            "Water",
+            "Grass"
+         ],
+         "perfect_cp":342,
+         "perfect_cp_boosted":427
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Lombre",
+         "id":"271",
+         "types":[
+            "Water",
+            "Grass"
+         ],
+         "perfect_cp":684,
+         "perfect_cp_boosted":855
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Ludicolo",
+         "id":"272",
+         "types":[
+            "Water",
+            "Grass"
+         ],
+         "perfect_cp":1327,
+         "perfect_cp_boosted":1659
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Seedot",
+         "id":"273",
+         "types":[
+            "Grass"
+         ],
+         "perfect_cp":342,
+         "perfect_cp_boosted":427
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Nuzleaf",
+         "id":"274",
+         "types":[
+            "Grass",
+            "Dark"
+         ],
+         "perfect_cp":701,
+         "perfect_cp_boosted":876
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Shiftry",
+         "id":"275",
+         "types":[
+            "Grass",
+            "Dark"
+         ],
+         "perfect_cp":1333,
+         "perfect_cp_boosted":1666,
+         "raid_level":4
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Taillow",
+         "id":"276",
+         "types":[
+            "Normal",
+            "Flying"
+         ],
+         "perfect_cp":437,
+         "perfect_cp_boosted":546
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Swellow",
+         "id":"277",
+         "types":[
+            "Normal",
+            "Flying"
+         ],
+         "perfect_cp":1097,
+         "perfect_cp_boosted":1371
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Wingull",
+         "id":"278",
+         "types":[
+            "Water",
+            "Flying"
+         ],
+         "perfect_cp":437,
+         "perfect_cp_boosted":546,
+         "raid_level":1
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Pelipper",
+         "id":"279",
+         "types":[
+            "Water",
+            "Flying"
+         ],
+         "perfect_cp":1215,
+         "perfect_cp_boosted":1519
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Ralts",
+         "id":"280",
+         "types":[
+            "Psychic",
+            "Fairy"
+         ],
+         "perfect_cp":308,
+         "perfect_cp_boosted":385
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Kirlia",
+         "id":"281",
+         "raid_level":2,
+         "types":[
+            "Psychic",
+            "Fairy"
+         ],
+         "perfect_cp":552,
+         "perfect_cp_boosted":690
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Gardevoir",
+         "id":"282",
+         "types":[
+            "Psychic",
+            "Fairy"
+         ],
+         "perfect_cp":1767,
+         "perfect_cp_boosted":2209
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Surskit",
+         "id":"283",
+         "types":[
+            "Bug",
+            "Water"
+         ],
+         "perfect_cp":452,
+         "perfect_cp_boosted":565
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Masquerain",
+         "id":"284",
+         "types":[
+            "Bug",
+            "Flying"
+         ],
+         "perfect_cp":1297,
+         "perfect_cp_boosted":1622
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Shroomish",
+         "id":"285",
+         "types":[
+            "Grass"
+         ],
+         "perfect_cp":463,
+         "perfect_cp_boosted":578
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Breloom",
+         "id":"286",
+         "raid_level":2,
+         "types":[
+            "Grass",
+            "Fighting"
+         ],
+         "perfect_cp":1502,
+         "perfect_cp_boosted":1877,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Slakoth",
+         "id":"287",
+         "types":[
+            "Normal"
+         ],
+         "perfect_cp":572,
+         "perfect_cp_boosted":716
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Vigoroth",
+         "id":"288",
+         "types":[
+            "Normal"
+         ],
+         "perfect_cp":1124,
+         "perfect_cp_boosted":1405
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Slaking",
+         "id":"289",
+         "types":[
+            "Normal"
+         ],
+         "perfect_cp":2532,
+         "perfect_cp_boosted":3165
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Nincada",
+         "id":"290",
+         "types":[
+            "Bug",
+            "Ground"
+         ],
+         "perfect_cp":439,
+         "perfect_cp_boosted":549
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Ninjask",
+         "id":"291",
+         "types":[
+            "Bug",
+            "Flying"
+         ],
+         "perfect_cp":1109,
+         "perfect_cp_boosted":1387
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Shedinja",
+         "id":"292",
+         "types":[
+            "Bug",
+            "Ghost"
+         ],
+         "perfect_cp":224,
+         "perfect_cp_boosted":281
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Whismur",
+         "id":"293",
+         "types":[
+            "Normal"
+         ],
+         "perfect_cp":383,
+         "perfect_cp_boosted":479
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Loudred",
+         "id":"294",
+         "types":[
+            "Normal"
+         ],
+         "perfect_cp":758,
+         "perfect_cp_boosted":948
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Exploud",
+         "id":"295",
+         "types":[
+            "Normal"
+         ],
+         "perfect_cp":1341,
+         "perfect_cp_boosted":1677
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Makuhita",
+         "id":"296",
+         "shiny":true,
+         "raid_level":1,
+         "types":[
+            "Fighting"
+         ],
+         "perfect_cp":467,
+         "perfect_cp_boosted":583,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Hariyama",
+         "id":"297",
+         "types":[
+            "Fighting"
+         ],
+         "perfect_cp":1616,
+         "perfect_cp_boosted":2020
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Azurill",
+         "id":"298",
+         "types":[
+            "Normal",
+            "Fairy"
+         ],
+         "perfect_cp":208,
+         "perfect_cp_boosted":260
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Nosepass",
+         "id":"299",
+         "types":[
+            "Rock"
+         ],
+         "perfect_cp":567,
+         "perfect_cp_boosted":709
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Skitty",
+         "id":"300",
+         "types":[
+            "Normal"
+         ],
+         "perfect_cp":422,
+         "perfect_cp_boosted":527
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Delcatty",
+         "id":"301",
+         "types":[
+            "Normal"
+         ],
+         "perfect_cp":854,
+         "perfect_cp_boosted":1068
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Sableye",
+         "id":"302",
+         "raid_level":2,
+         "types":[
+            "Dark",
+            "Ghost"
+         ],
+         "perfect_cp":843,
+         "perfect_cp_boosted":1054
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Mawile",
+         "id":"303",
+         "raid_level":2,
+         "perfect_cp":934,
+         "perfect_cp_boosted":1167,
+         "shiny":true,
+         "types":[
+            "Steel",
+            "Fairy"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Aron",
+         "id":"304",
+         "types":[
+            "Steel",
+            "Rock"
+         ],
+         "perfect_cp":747,
+         "perfect_cp_boosted":934
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Lairon",
+         "id":"305",
+         "types":[
+            "Steel",
+            "Rock"
+         ],
+         "perfect_cp":1174,
+         "perfect_cp_boosted":1468
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Aggron",
+         "id":"306",
+         "raid_level":4,
+         "perfect_cp":1714,
+         "perfect_cp_boosted":2143,
+         "types":[
+            "Steel",
+            "Rock"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Meditite",
+         "id":"307",
+         "raid_level":1,
+         "types":[
+            "Fighting",
+            "Psychic"
+         ],
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "perfect_cp":396,
+         "perfect_cp_boosted":495
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Medicham",
+         "id":"308",
+         "types":[
+            "Fighting",
+            "Psychic"
+         ],
+         "perfect_cp":817,
+         "perfect_cp_boosted":1022
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Electrike",
+         "id":"309",
+         "types":[
+            "Electric"
+         ],
+         "perfect_cp":551,
+         "perfect_cp_boosted":689
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Manectric",
+         "id":"310",
+         "raid_level":2,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Electric"
+         ],
+         "perfect_cp":1337,
+         "perfect_cp_boosted":1672
+      },
+      "availability_rules":[
+
+      ]
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Plusle",
+         "id":"311",
+         "types":[
+            "Electric"
+         ],
+         "perfect_cp":1016,
+         "perfect_cp_boosted":1270,
+         "raid_level":1
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Minun",
+         "id":"312",
+         "types":[
+            "Electric"
+         ],
+         "perfect_cp":968,
+         "perfect_cp_boosted":1210,
+         "raid_level":1
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Volbeat",
+         "id":"313",
+         "types":[
+            "Bug"
+         ],
+         "perfect_cp":1012,
+         "perfect_cp_boosted":1265
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Illumise",
+         "id":"314",
+         "types":[
+            "Bug"
+         ],
+         "perfect_cp":1012,
+         "perfect_cp_boosted":1265
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Roselia",
+         "id":"315",
+         "raid_level":2,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "perfect_cp":1068,
+         "perfect_cp_boosted":1335,
+         "types":[
+            "Grass",
+            "Poison"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Gulpin",
+         "id":"316",
+         "types":[
+            "Poison"
+         ],
+         "perfect_cp":495,
+         "perfect_cp_boosted":618
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Swalot",
+         "id":"317",
+         "types":[
+            "Poison"
+         ],
+         "perfect_cp":1130,
+         "perfect_cp_boosted":1413
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Carvanha",
+         "id":"318",
+         "types":[
+            "Water",
+            "Dark"
+         ],
+         "perfect_cp":583,
+         "perfect_cp_boosted":729
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Sharpedo",
+         "id":"319",
+         "raid_level":3,
+         "perfect_cp":1246,
+         "perfect_cp_boosted":1558,
+         "shiny":true,
+         "types":[
+            "Water",
+            "Dark"
+         ],
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Wailmer",
+         "id":"320",
+         "raid_level":1,
+         "perfect_cp":838,
+         "perfect_cp_boosted":1048,
+         "shiny":true,
+         "types":[
+            "Water"
+         ],
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Wailord",
+         "id":"321",
+         "types":[
+            "Water"
+         ],
+         "perfect_cp":1302,
+         "perfect_cp_boosted":1628
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Numel",
+         "id":"322",
+         "types":[
+            "Fire",
+            "Ground"
+         ],
+         "perfect_cp":604,
+         "perfect_cp_boosted":755
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Camerupt",
+         "id":"323",
+         "types":[
+            "Fire",
+            "Ground"
+         ],
+         "perfect_cp":1253,
+         "perfect_cp_boosted":1566
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Torkoal",
+         "id":"324",
+         "types":[
+            "Fire"
+         ],
+         "perfect_cp":1196,
+         "perfect_cp_boosted":1495
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Spoink",
+         "id":"325",
+         "types":[
+            "Psychic"
+         ],
+         "perfect_cp":762,
+         "perfect_cp_boosted":953
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Grumpig",
+         "id":"326",
+         "types":[
+            "Psychic"
+         ],
+         "perfect_cp":1354,
+         "perfect_cp_boosted":1692
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Spinda",
+         "id":"327",
+         "types":[
+            "Normal"
+         ],
+         "perfect_cp":697,
+         "perfect_cp_boosted":872
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Trapinch",
+         "id":"328",
+         "types":[
+            "Ground"
+         ],
+         "perfect_cp":728,
+         "perfect_cp_boosted":910
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Vibrava",
+         "id":"329",
+         "types":[
+            "Ground",
+            "Dragon"
+         ],
+         "perfect_cp":699,
+         "perfect_cp_boosted":875
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Flygon",
+         "id":"330",
+         "types":[
+            "Ground",
+            "Dragon"
+         ],
+         "perfect_cp":1520,
+         "perfect_cp_boosted":1901
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Cacnea",
+         "id":"331",
+         "types":[
+            "Grass"
+         ],
+         "perfect_cp":709,
+         "perfect_cp_boosted":887
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Cacturne",
+         "id":"332",
+         "types":[
+            "Grass",
+            "Dark"
+         ],
+         "perfect_cp":1313,
+         "perfect_cp_boosted":1641
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Swablu",
+         "id":"333",
+         "raid_level":1,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Normal",
+            "Flying"
+         ],
+         "perfect_cp":470,
+         "perfect_cp_boosted":588
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Altaria",
+         "id":"334",
+         "types":[
+            "Dragon",
+            "Flying"
+         ],
+         "perfect_cp":1145,
+         "perfect_cp_boosted":1432
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Zangoose",
+         "id":"335",
+         "types":[
+            "Normal"
+         ],
+         "perfect_cp":1381,
+         "perfect_cp_boosted":1727
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Seviper",
+         "id":"336",
+         "types":[
+            "Poison"
+         ],
+         "perfect_cp":1203,
+         "perfect_cp_boosted":1504
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Lunatone",
+         "id":"337",
+         "types":[
+            "Rock",
+            "Psychic"
+         ],
+         "perfect_cp":1330,
+         "perfect_cp_boosted":1662,
+         "raid_level":3
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Solrock",
+         "id":"338",
+         "types":[
+            "Rock",
+            "Psychic"
+         ],
+         "perfect_cp":1330,
+         "perfect_cp_boosted":1662,
+         "raid_level":3
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Barboach",
+         "id":"339",
+         "types":[
+            "Water",
+            "Ground"
+         ],
+         "perfect_cp":468,
+         "perfect_cp_boosted":585
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Whiscash",
+         "id":"340",
+         "types":[
+            "Water",
+            "Ground"
+         ],
+         "perfect_cp":1186,
+         "perfect_cp_boosted":1482
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Corphish",
+         "id":"341",
+         "types":[
+            "Water"
+         ],
+         "perfect_cp":703,
+         "perfect_cp_boosted":879
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Crawdaunt",
+         "id":"342",
+         "types":[
+            "Water",
+            "Dark"
+         ],
+         "perfect_cp":1413,
+         "perfect_cp_boosted":1767,
+         "raid_level":3
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Baltoy",
+         "id":"343",
+         "types":[
+            "Ground",
+            "Psychic"
+         ],
+         "perfect_cp":449,
+         "perfect_cp_boosted":562
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Claydol",
+         "id":"344",
+         "raid_level":3,
+         "perfect_cp":1126,
+         "perfect_cp_boosted":1408,
+         "types":[
+            "Ground",
+            "Psychic"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Lileep",
+         "id":"345",
+         "types":[
+            "Rock",
+            "Grass"
+         ],
+         "perfect_cp":738,
+         "perfect_cp_boosted":922
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Cradily",
+         "id":"346",
+         "types":[
+            "Rock",
+            "Grass"
+         ],
+         "perfect_cp":1263,
+         "perfect_cp_boosted":1579
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Anorith",
+         "id":"347",
+         "types":[
+            "Rock",
+            "Bug"
+         ],
+         "perfect_cp":874,
+         "perfect_cp_boosted":1092
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Armaldo",
+         "id":"348",
+         "types":[
+            "Rock",
+            "Bug"
+         ],
+         "perfect_cp":1627,
+         "perfect_cp_boosted":2035
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Feebas",
+         "id":"349",
+         "types":[
+            "Water"
+         ],
+         "perfect_cp":157,
+         "perfect_cp_boosted":196
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Milotic",
+         "id":"350",
+         "types":[
+            "Water"
+         ],
+         "perfect_cp":1717,
+         "perfect_cp_boosted":2147
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Castform",
+         "id":"351",
+         "types":[
+            "Fire"
+         ],
+         "perfect_cp":932,
+         "perfect_cp_boosted":1165
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Kecleon",
+         "id":"352",
+         "types":[
+            "Normal"
+         ],
+         "perfect_cp":1169,
+         "perfect_cp_boosted":1462
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Shuppet",
+         "id":"353",
+         "raid_level":1,
+         "types":[
+            "Ghost"
+         ],
+         "perfect_cp":581,
+         "perfect_cp_boosted":727
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Banette",
+         "id":"354",
+         "types":[
+            "Ghost"
+         ],
+         "perfect_cp":1313,
+         "perfect_cp_boosted":1642
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Duskull",
+         "id":"355",
+         "raid_level":1,
+         "types":[
+            "Ghost"
+         ],
+         "perfect_cp":403,
+         "perfect_cp_boosted":504
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Dusclops",
+         "id":"356",
+         "types":[
+            "Ghost"
+         ],
+         "perfect_cp":909,
+         "perfect_cp_boosted":1136
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Tropius",
+         "id":"357",
+         "types":[
+            "Grass",
+            "Flying"
+         ],
+         "perfect_cp":1109,
+         "perfect_cp_boosted":1386
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Chimecho",
+         "id":"358",
+         "types":[
+            "Psychic"
+         ],
+         "perfect_cp":1291,
+         "perfect_cp_boosted":1614
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Absol",
+         "id":"359",
+         "raid_level":4,
+         "perfect_cp":1443,
+         "perfect_cp_boosted":1805,
+         "shiny":true,
+         "types":[
+            "Dark"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Wynaut",
+         "id":"360",
+         "types":[
+            "Psychic"
+         ],
+         "perfect_cp":305,
+         "perfect_cp_boosted":381
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Snorunt",
+         "id":"361",
+         "raid_level":1,
+         "types":[
+            "Ice"
+         ],
+         "perfect_cp":507,
+         "perfect_cp_boosted":634,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Glalie",
+         "id":"362",
+         "types":[
+            "Ice"
+         ],
+         "perfect_cp":1203,
+         "perfect_cp_boosted":1504
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Spheal",
+         "id":"363",
+         "types":[
+            "Ice",
+            "Water"
+         ],
+         "perfect_cp":550,
+         "perfect_cp_boosted":687
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Sealeo",
+         "id":"364",
+         "types":[
+            "Ice",
+            "Water"
+         ],
+         "perfect_cp":979,
+         "perfect_cp_boosted":1225
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Walrein",
+         "id":"365",
+         "raid_level":4,
+         "perfect_cp":1557,
+         "perfect_cp_boosted":1947,
+         "types":[
+            "Ice",
+            "Water"
+         ],
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Clamperl",
+         "id":"366",
+         "types":[
+            "Water"
+         ],
+         "perfect_cp":726,
+         "perfect_cp_boosted":907
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Huntail",
+         "id":"367",
+         "types":[
+            "Water"
+         ],
+         "perfect_cp":1337,
+         "perfect_cp_boosted":1671
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Gorebyss",
+         "id":"368",
+         "types":[
+            "Water"
+         ],
+         "perfect_cp":1425,
+         "perfect_cp_boosted":1781
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Relicanth",
+         "id":"369",
+         "types":[
+            "Water",
+            "Rock"
+         ],
+         "perfect_cp":1444,
+         "perfect_cp_boosted":1806
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Luvdisc",
+         "id":"370",
+         "types":[
+            "Water"
+         ],
+         "perfect_cp":484,
+         "perfect_cp_boosted":605
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Bagon",
+         "id":"371",
+         "types":[
+            "Dragon"
+         ],
+         "perfect_cp":660,
+         "perfect_cp_boosted":826
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Shelgon",
+         "id":"372",
+         "types":[
+            "Dragon"
+         ],
+         "perfect_cp":1160,
+         "perfect_cp_boosted":1451
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Salamence",
+         "id":"373",
+         "types":[
+            "Dragon",
+            "Flying"
+         ],
+         "perfect_cp":2142,
+         "perfect_cp_boosted":2678
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Beldum",
+         "id":"374",
+         "types":[
+            "Steel",
+            "Psychic"
+         ],
+         "perfect_cp":558,
+         "perfect_cp_boosted":697
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Metang",
+         "id":"375",
+         "types":[
+            "Steel",
+            "Psychic"
+         ],
+         "perfect_cp":983,
+         "perfect_cp_boosted":1229
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Metagross",
+         "id":"376",
+         "types":[
+            "Steel",
+            "Psychic"
+         ],
+         "perfect_cp":2166,
+         "perfect_cp_boosted":2708,
+         "raid_level":4
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Regirock",
+         "id":"377",
+         "types":[
+            "Rock"
+         ],
+         "perfect_cp":1784,
+         "perfect_cp_boosted":2230,
+         "raid_level":5,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Regice",
+         "id":"378",
+         "types":[
+            "Ice"
+         ],
+         "raid_level":5,
+         "perfect_cp":1784,
+         "perfect_cp_boosted":2230,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Registeel",
+         "id":"379",
+         "types":[
+            "Steel"
+         ],
+         "perfect_cp":1398,
+         "perfect_cp_boosted":1748,
+         "raid_level":5,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Latias",
+         "id":"380",
+         "raid_level":5,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Dragon",
+            "Psychic"
+         ],
+         "perfect_cp":2006,
+         "perfect_cp_boosted":2507
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Latios",
+         "id":"381",
+         "raid_level":5,
+         "types":[
+            "Dragon",
+            "Psychic"
+         ],
+         "perfect_cp":2178,
+         "perfect_cp_boosted":2723,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Kyogre",
+         "id":"382",
+         "raid_level":5,
+         "types":[
+            "Water"
+         ],
+         "shiny":true,
+         "perfect_cp":2351,
+         "perfect_cp_boosted":2939
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Groudon",
+         "id":"383",
+         "raid_level":5,
+         "types":[
+            "Ground"
+         ],
+         "shiny":true,
+         "perfect_cp":2351,
+         "perfect_cp_boosted":2939
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Rayquaza",
+         "id":"384",
+         "raid_level":5,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Dragon",
+            "Flying"
+         ],
+         "perfect_cp":2191,
+         "perfect_cp_boosted":2739
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Deoxys",
+         "id":"386",
+         "perfect_cp":1645,
+         "perfect_cp_boosted":2056,
+         "raid_level":5,
+         "ex":true,
+         "types":[
+            "Psychic"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Bidoof",
+         "id":"399",
+         "raid_level":1,
+         "perfect_cp":412,
+         "perfect_cp_boosted":515,
+         "types":[
+            "Normal"
+         ],
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Kricketot",
+         "id":"401",
+         "raid_level":1,
+         "perfect_cp":229,
+         "perfect_cp_boosted":286,
+         "types":[
+            "Bug"
+         ],
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Shinx",
+         "id":"403",
+         "shiny":true,
+         "raid_level":1,
+         "perfect_cp":500,
+         "perfect_cp_boosted":625,
+         "types":[
+            "Electric"
+         ],
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Buneary",
+         "id":"427",
+         "raid_level":1,
+         "perfect_cp":719,
+         "perfect_cp_boosted":899,
+         "types":[
+            "Normal"
+         ],
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Giratina",
+         "id":"487",
+         "raid_level":5,
+         "perfect_cp":2105,
+         "perfect_cp_boosted":2631,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ],
+         "types":[
+            "Ghost",
+            "Dragon"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Jirachi",
+         "id":385,
+         "perfect_cp":1865,
+         "perfect_cp_boosted":2332,
+         "types":[
+            "Steel",
+            "Psychic"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Turtwig",
+         "id":387,
+         "perfect_cp":678,
+         "perfect_cp_boosted":848,
+         "types":[
+            "Grass"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Grotle",
+         "id":388,
+         "perfect_cp":1080,
+         "perfect_cp_boosted":1350,
+         "types":[
+            "Grass"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Torterra",
+         "id":389,
+         "perfect_cp":1677,
+         "perfect_cp_boosted":2096,
+         "types":[
+            "Grass",
+            "Ground"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Chimchar",
+         "id":390,
+         "perfect_cp":547,
+         "perfect_cp_boosted":683,
+         "types":[
+            "Fire"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Monferno",
+         "id":391,
+         "perfect_cp":899,
+         "perfect_cp_boosted":1124,
+         "types":[
+            "Fire",
+            "Fighting"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Infernape",
+         "id":392,
+         "perfect_cp":1533,
+         "perfect_cp_boosted":1916,
+         "types":[
+            "Fire",
+            "Fighting"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Piplup",
+         "id":393,
+         "perfect_cp":614,
+         "perfect_cp_boosted":767,
+         "types":[
+            "Water"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Prinplup",
+         "id":394,
+         "perfect_cp":972,
+         "perfect_cp_boosted":1215,
+         "types":[
+            "Water"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Empoleon",
+         "id":395,
+         "perfect_cp":1657,
+         "perfect_cp_boosted":2072,
+         "types":[
+            "Water",
+            "Steel"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Starly",
+         "id":396,
+         "perfect_cp":410,
+         "perfect_cp_boosted":513,
+         "types":[
+            "Normal",
+            "Flying"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Staravia",
+         "id":397,
+         "perfect_cp":742,
+         "perfect_cp_boosted":927,
+         "types":[
+            "Normal",
+            "Flying"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Staraptor",
+         "id":398,
+         "perfect_cp":1614,
+         "perfect_cp_boosted":2018,
+         "types":[
+            "Normal",
+            "Flying"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Bibarel",
+         "id":400,
+         "perfect_cp":1041,
+         "perfect_cp_boosted":1302,
+         "types":[
+            "Normal",
+            "Water"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Kricketune",
+         "id":402,
+         "perfect_cp":944,
+         "perfect_cp_boosted":1181,
+         "types":[
+            "Bug"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Luxio",
+         "id":404,
+         "perfect_cp":849,
+         "perfect_cp_boosted":1061,
+         "types":[
+            "Electric"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Luxray",
+         "id":405,
+         "perfect_cp":1650,
+         "perfect_cp_boosted":2063,
+         "types":[
+            "Electric"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Budew",
+         "id":406,
+         "perfect_cp":489,
+         "perfect_cp_boosted":611,
+         "types":[
+            "Grass",
+            "Poison"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Roserade",
+         "id":407,
+         "perfect_cp":1697,
+         "perfect_cp_boosted":2122,
+         "types":[
+            "Grass",
+            "Poison"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Cranidos",
+         "id":408,
+         "perfect_cp":1040,
+         "perfect_cp_boosted":1300,
+         "types":[
+            "Rock",
+            "Rock"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Rampardos",
+         "id":409,
+         "perfect_cp":1884,
+         "perfect_cp_boosted":2355,
+         "types":[
+            "Rock",
+            "Rock"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Shieldon",
+         "id":410,
+         "perfect_cp":509,
+         "perfect_cp_boosted":636,
+         "types":[
+            "Rock",
+            "Steel"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Bastiodon",
+         "id":411,
+         "perfect_cp":879,
+         "perfect_cp_boosted":1100,
+         "types":[
+            "Rock",
+            "Steel"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Burmy",
+         "id":412,
+         "perfect_cp":279,
+         "perfect_cp_boosted":348,
+         "types":[
+            "Bug"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Wormadam Trash",
+         "id":413,
+         "perfect_cp":910,
+         "perfect_cp_boosted":1138,
+         "types":[
+            "Bug",
+            "Steel"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Mothim",
+         "id":414,
+         "perfect_cp":1037,
+         "perfect_cp_boosted":1297,
+         "types":[
+            "Bug",
+            "Flying"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Combee",
+         "id":415,
+         "perfect_cp":282,
+         "perfect_cp_boosted":353,
+         "types":[
+            "Bug",
+            "Flying"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Vespiquen",
+         "id":416,
+         "perfect_cp":1145,
+         "perfect_cp_boosted":1432,
+         "types":[
+            "Bug",
+            "Flying"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Pachirisu",
+         "id":417,
+         "perfect_cp":693,
+         "perfect_cp_boosted":867,
+         "types":[
+            "Electric"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Buizel",
+         "id":418,
+         "perfect_cp":602,
+         "perfect_cp_boosted":753,
+         "types":[
+            "Water"
+         ],
+         "raid_level":1,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Floatzel",
+         "id":419,
+         "perfect_cp":1396,
+         "perfect_cp_boosted":1745,
+         "types":[
+            "Water"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Cherubi",
+         "id":420,
+         "perfect_cp":542,
+         "perfect_cp_boosted":678,
+         "types":[
+            "Grass"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Cherrim Sunny",
+         "id":421,
+         "perfect_cp":1170,
+         "perfect_cp_boosted":1462,
+         "types":[
+            "Grass"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Shellos West Sea",
+         "id":422,
+         "perfect_cp":649,
+         "perfect_cp_boosted":811,
+         "types":[
+            "Water"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Gastrodon West Sea",
+         "id":423,
+         "perfect_cp":1328,
+         "perfect_cp_boosted":1660,
+         "types":[
+            "Water",
+            "Ground"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Ambipom",
+         "id":424,
+         "perfect_cp":1381,
+         "perfect_cp_boosted":1727,
+         "types":[
+            "Normal"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Drifloon",
+         "id":425,
+         "perfect_cp":684,
+         "perfect_cp_boosted":855,
+         "types":[
+            "Ghost",
+            "Flying"
+         ],
+         "raid_level":1,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Drifblim",
+         "id":426,
+         "perfect_cp":1361,
+         "perfect_cp_boosted":1701,
+         "types":[
+            "Ghost",
+            "Flying"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Lopunny",
+         "id":428,
+         "perfect_cp":1177,
+         "perfect_cp_boosted":1471,
+         "types":[
+            "Normal"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Mismagius",
+         "id":429,
+         "perfect_cp":1494,
+         "perfect_cp_boosted":1868,
+         "types":[
+            "Ghost"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Honchkrow",
+         "id":430,
+         "perfect_cp":1549,
+         "perfect_cp_boosted":1937,
+         "types":[
+            "Dark",
+            "Flying"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Glameow",
+         "id":431,
+         "perfect_cp":533,
+         "perfect_cp_boosted":667,
+         "types":[
+            "Normal"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Purugly",
+         "id":432,
+         "perfect_cp":1116,
+         "perfect_cp_boosted":1395,
+         "types":[
+            "Normal"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Chingling",
+         "id":433,
+         "perfect_cp":574,
+         "perfect_cp_boosted":718,
+         "types":[
+            "Psychic"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Stunky",
+         "id":434,
+         "perfect_cp":657,
+         "perfect_cp_boosted":822,
+         "types":[
+            "Poison",
+            "Dark"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Skuntank",
+         "id":435,
+         "perfect_cp":1347,
+         "perfect_cp_boosted":1684,
+         "types":[
+            "Poison",
+            "Dark"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Bronzor",
+         "id":436,
+         "perfect_cp":344,
+         "perfect_cp_boosted":430,
+         "types":[
+            "Steel",
+            "Psychic"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Bronzong",
+         "id":437,
+         "perfect_cp":1279,
+         "perfect_cp_boosted":1599,
+         "types":[
+            "Steel",
+            "Psychic"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Bonsly",
+         "id":438,
+         "perfect_cp":744,
+         "perfect_cp_boosted":930,
+         "types":[
+            "Rock"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Mime Jr",
+         "id":439,
+         "perfect_cp":626,
+         "perfect_cp_boosted":782,
+         "types":[
+            "Psychic",
+            "Fairy"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Happiny",
+         "id":440,
+         "perfect_cp":212,
+         "perfect_cp_boosted":265,
+         "types":[
+            "Normal"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Chatot",
+         "id":441,
+         "perfect_cp":1023,
+         "perfect_cp_boosted":1279,
+         "types":[
+            "Normal",
+            "Flying"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Spiritomb",
+         "id":442,
+         "perfect_cp":1184,
+         "perfect_cp_boosted":1480,
+         "types":[
+            "Ghost",
+            "Dark"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Gible",
+         "id":443,
+         "perfect_cp":635,
+         "perfect_cp_boosted":794,
+         "types":[
+            "Dragon",
+            "Ground"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Gabite",
+         "id":444,
+         "perfect_cp":1071,
+         "perfect_cp_boosted":1339,
+         "types":[
+            "Dragon",
+            "Ground"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Garchomp",
+         "id":445,
+         "perfect_cp":2264,
+         "perfect_cp_boosted":2830,
+         "types":[
+            "Dragon",
+            "Ground"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Munchlax",
+         "id":446,
+         "perfect_cp":1081,
+         "perfect_cp_boosted":1351,
+         "types":[
+            "Normal"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Riolu",
+         "id":447,
+         "perfect_cp":567,
+         "perfect_cp_boosted":709,
+         "types":[
+            "Fighting"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Lucario",
+         "id":448,
+         "perfect_cp":1544,
+         "perfect_cp_boosted":1930,
+         "types":[
+            "Fighting",
+            "Steel"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Hippopotas",
+         "id":449,
+         "perfect_cp":776,
+         "perfect_cp_boosted":970,
+         "types":[
+            "Ground"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Hippowdon",
+         "id":450,
+         "perfect_cp":1763,
+         "perfect_cp_boosted":2204,
+         "types":[
+            "Ground"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Skorupi",
+         "id":451,
+         "perfect_cp":576,
+         "perfect_cp_boosted":721,
+         "types":[
+            "Poison",
+            "Bug"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Drapion",
+         "id":452,
+         "perfect_cp":1401,
+         "perfect_cp_boosted":1752,
+         "types":[
+            "Poison",
+            "Dark"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Croagunk",
+         "id":453,
+         "perfect_cp":544,
+         "perfect_cp_boosted":680,
+         "types":[
+            "Poison",
+            "Fighting"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Toxicroak",
+         "id":454,
+         "perfect_cp":1421,
+         "perfect_cp_boosted":1777,
+         "types":[
+            "Poison",
+            "Fighting"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Carnivine",
+         "id":455,
+         "perfect_cp":1233,
+         "perfect_cp_boosted":1542,
+         "types":[
+            "Grass"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Finneon",
+         "id":456,
+         "perfect_cp":555,
+         "perfect_cp_boosted":694,
+         "types":[
+            "Water"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Lumineon",
+         "id":457,
+         "perfect_cp":1036,
+         "perfect_cp_boosted":1295,
+         "types":[
+            "Water"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Mantyke",
+         "id":458,
+         "perfect_cp":713,
+         "perfect_cp_boosted":891,
+         "types":[
+            "Water",
+            "Flying"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Snover",
+         "id":459,
+         "perfect_cp":662,
+         "perfect_cp_boosted":828,
+         "types":[
+            "Grass",
+            "Ice"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Abomasnow",
+         "id":460,
+         "perfect_cp":1349,
+         "perfect_cp_boosted":1687,
+         "types":[
+            "Grass",
+            "Ice"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Weavile",
+         "id":461,
+         "perfect_cp":1717,
+         "perfect_cp_boosted":2146,
+         "types":[
+            "Dark",
+            "Ice"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Magnezone",
+         "id":462,
+         "perfect_cp":1831,
+         "perfect_cp_boosted":2289,
+         "types":[
+            "Electric",
+            "Steel"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Lickilicky",
+         "id":463,
+         "perfect_cp":1409,
+         "perfect_cp_boosted":1762,
+         "types":[
+            "Normal"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Rhyperior",
+         "id":464,
+         "perfect_cp":2133,
+         "perfect_cp_boosted":2667,
+         "types":[
+            "Ground",
+            "Rock"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Tangrowth",
+         "id":465,
+         "perfect_cp":1731,
+         "perfect_cp_boosted":2164,
+         "types":[
+            "Grass"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Electivire",
+         "id":466,
+         "perfect_cp":1759,
+         "perfect_cp_boosted":2199,
+         "types":[
+            "Electric"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Magmortar",
+         "id":467,
+         "perfect_cp":1790,
+         "perfect_cp_boosted":2237,
+         "types":[
+            "Fire"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Togekiss",
+         "id":468,
+         "perfect_cp":1904,
+         "perfect_cp_boosted":2380,
+         "types":[
+            "Fairy",
+            "Flying"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Yanmega",
+         "id":469,
+         "perfect_cp":1683,
+         "perfect_cp_boosted":2104,
+         "types":[
+            "Bug",
+            "Flying"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Leafeon",
+         "id":470,
+         "perfect_cp":1682,
+         "perfect_cp_boosted":2103,
+         "types":[
+            "Grass"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Glaceon",
+         "id":471,
+         "perfect_cp":1786,
+         "perfect_cp_boosted":2233,
+         "types":[
+            "Ice"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Gliscor",
+         "id":472,
+         "perfect_cp":1538,
+         "perfect_cp_boosted":1923,
+         "types":[
+            "Ground",
+            "Flying"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Mamoswine",
+         "id":473,
+         "perfect_cp":1902,
+         "perfect_cp_boosted":2377,
+         "types":[
+            "Ice",
+            "Ground"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Porygon Z",
+         "id":474,
+         "perfect_cp":1866,
+         "perfect_cp_boosted":2333,
+         "types":[
+            "Normal"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Gallade",
+         "id":475,
+         "perfect_cp":1767,
+         "perfect_cp_boosted":2209,
+         "types":[
+            "Psychic",
+            "Fighting"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Probopass",
+         "id":476,
+         "perfect_cp":1188,
+         "perfect_cp_boosted":1485,
+         "types":[
+            "Rock",
+            "Steel"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Dusknoir",
+         "id":477,
+         "perfect_cp":1364,
+         "perfect_cp_boosted":1706,
+         "types":[
+            "Ghost"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Froslass",
+         "id":478,
+         "perfect_cp":1166,
+         "perfect_cp_boosted":1457,
+         "types":[
+            "Ice",
+            "Ghost"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Rotom Wash",
+         "id":479,
+         "perfect_cp":1474,
+         "perfect_cp_boosted":1842,
+         "types":[
+            "Electric",
+            "Water"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Uxie",
+         "id":480,
+         "perfect_cp":1442,
+         "perfect_cp_boosted":1803,
+         "types":[
+            "Psychic"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Mesprit",
+         "id":481,
+         "perfect_cp":1747,
+         "perfect_cp_boosted":2184,
+         "types":[
+            "Psychic"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Azelf",
+         "id":482,
+         "perfect_cp":1834,
+         "perfect_cp_boosted":2293,
+         "types":[
+            "Psychic"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Dialga",
+         "id":483,
+         "perfect_cp":2307,
+         "perfect_cp_boosted":2884,
+         "types":[
+            "Steel",
+            "Dragon"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Palkia",
+         "id":484,
+         "perfect_cp":2280,
+         "perfect_cp_boosted":2850,
+         "types":[
+            "Water",
+            "Dragon"
+         ],
+         "raid_level":5,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2019-01-29T21:00:00Z",
+                  "end":"2019-02-28T21:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Heatran",
+         "id":485,
+         "perfect_cp":2145,
+         "perfect_cp_boosted":2681,
+         "types":[
+            "Fire",
+            "Steel"
+         ],
+         "raid_level":5,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Regigigas",
+         "id":486,
+         "perfect_cp":2483,
+         "perfect_cp_boosted":3104,
+         "types":[
+            "Normal"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Cresselia",
+         "id":488,
+         "perfect_cp":1633,
+         "perfect_cp_boosted":2041,
+         "types":[
+            "Psychic"
+         ],
+         "raid_level":5,
+         "availability_rules":[
+            [
+               {
+                  "type":"time",
+                  "start":"2010-06-07T20:00:00Z",
+                  "end":"2010-06-07T20:00:00Z"
+               }
+            ]
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Phione",
+         "id":489,
+         "perfect_cp":1203,
+         "perfect_cp_boosted":1504,
+         "types":[
+            "Water"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Manaphy",
+         "id":490,
+         "perfect_cp":1865,
+         "perfect_cp_boosted":2332,
+         "types":[
+            "Water"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Darkrai",
+         "id":491,
+         "perfect_cp":2136,
+         "perfect_cp_boosted":2671,
+         "types":[
+            "Dark"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Shaymin Sky",
+         "id":492,
+         "perfect_cp":2052,
+         "perfect_cp_boosted":2566,
+         "types":[
+            "Grass",
+            "Flying"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Arceus Water",
+         "id":493,
+         "perfect_cp":2279,
+         "perfect_cp_boosted":2850,
+         "types":[
+            "Water"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Meltan",
+         "id":808,
+         "perfect_cp":617,
+         "perfect_cp_boosted":771,
+         "types":[
+            "Steel"
+         ]
+      }
+   },
+   {
+      "type":"pokemon",
+      "data":{
+         "name":"Melmetal",
+         "id":809,
+         "perfect_cp":2214,
+         "perfect_cp_boosted":2768,
+         "types":[
+            "Steel"
+         ]
+      }
+   }
 ]


### PR DESCRIPTION
I spotted an unused key `perfect_boosted` which looks like it was put there in error, as it's the same as `perfect_cp_boosted` and the code doesn't make use of it. (I checked.)

I used `json.loads()`, a `for` loop and `json.dumps()` to do this so I then used a [JSON formatter](https://jsonformatter.curiousconcept.com/) to prettify it again for readability, unfortunately, I couldn't find one that perfectly matched your formatting scheme. (However, the only difference is no space after the `:`.)